### PR TITLE
SOL.NET Library Update to 4.17 from 4.2

### DIFF
--- a/Solnet.Metaplex.Examples/Solnet.Metaplex.Examples.csproj
+++ b/Solnet.Metaplex.Examples/Solnet.Metaplex.Examples.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
@@ -11,8 +11,9 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Solnet.Rpc" Version="0.4.2" />
-        <PackageReference Include="Solnet.Wallet" Version="0.4.2" />
+        <PackageReference Include="Solnet.Programs" Version="0.4.17" />
+        <PackageReference Include="Solnet.Rpc" Version="0.4.17" />
+        <PackageReference Include="Solnet.Wallet" Version="0.4.17" />
     </ItemGroup>
 
 </Project>

--- a/Solnet.Metaplex.Examples/packages.lock.json
+++ b/Solnet.Metaplex.Examples/packages.lock.json
@@ -2,22 +2,31 @@
   "version": 1,
   "dependencies": {
     ".NETCoreApp,Version=v5.0": {
+      "Solnet.Programs": {
+        "type": "Direct",
+        "requested": "[0.4.17, )",
+        "resolved": "0.4.17",
+        "contentHash": "uGfOM5zcE2uTTOHFaWiOj1fee/fi+QjgeTc57ETPPNIvkkm4i8PFZJ0HFdfehLNk1uDd2H277ua/ZJdFXwIz3w==",
+        "dependencies": {
+          "Solnet.Rpc": "0.4.17"
+        }
+      },
       "Solnet.Rpc": {
         "type": "Direct",
-        "requested": "[0.4.2, )",
-        "resolved": "0.4.2",
-        "contentHash": "55qQqaXmtFyBIGBJ/VaLqkxJSDTFAHEF6lMMWGpIV6p7EV99TTBSUtE2zFmDtImD8YkplocCIpwU7kWGdqLzAA==",
+        "requested": "[0.4.17, )",
+        "resolved": "0.4.17",
+        "contentHash": "wrcafmjYq2wUWIzH2e0kRG4+ANy05G+IzuN0/Ka9+4vXtsgv59c1ZozCHlULEER50/deQo0UjIcRcjgaqh7OsA==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "5.0.0",
           "Microsoft.Extensions.Logging.Console": "5.0.0",
-          "Solnet.Wallet": "0.4.2"
+          "Solnet.Wallet": "0.4.17"
         }
       },
       "Solnet.Wallet": {
         "type": "Direct",
-        "requested": "[0.4.2, )",
-        "resolved": "0.4.2",
-        "contentHash": "YHgndl6T6z4UTM6OYglIFqIj6zOJWbCaJGiILDA46LFnA0nIiWdqZM4yNucS2dI1P6fhkBTk7gnBRHlIS3RteA==",
+        "requested": "[0.4.17, )",
+        "resolved": "0.4.17",
+        "contentHash": "v/jzBQU52j7Vz9M6wOJlsShl5GUfea0lgt13T+dlbknFe07lceNScAv3uYRxR1cUQWuhIqsRNquLGp3VyhaJ3w==",
         "dependencies": {
           "Chaos.NaCl.Standard": "1.0.0",
           "Portable.BouncyCastle": "1.8.2"
@@ -144,20 +153,12 @@
       },
       "Solnet.KeyStore": {
         "type": "Transitive",
-        "resolved": "0.4.2",
-        "contentHash": "WIg/2YjcSmeJ3W41up1N12iyBrhc6nYq0aRoBGi3BJ5EQdSn/x8r3tE663rqDqU8ydi0IzfUgHXZd638nSLgVg==",
+        "resolved": "0.4.17",
+        "contentHash": "89w1PKk0e9Glzt/dW1vPfoH2utVINdi3+9875+Qh2tpC8iVEeNlGr7tJCY4J5WF8Ht9vCqcuEu1qJ55Mf+myKg==",
         "dependencies": {
           "Chaos.NaCl.Standard": "1.0.0",
           "Portable.BouncyCastle": "1.8.2",
-          "Solnet.Wallet": "0.4.2"
-        }
-      },
-      "Solnet.Programs": {
-        "type": "Transitive",
-        "resolved": "0.4.2",
-        "contentHash": "931jvjXMKjnDPZiKzLhdBRnt3miDu128HJ6Sqw0mIPZ8MXXdtKJ4KVz8SdU3iEi2oBrhc77Le7yJn1BJGWVVxg==",
-        "dependencies": {
-          "Solnet.Rpc": "0.4.2"
+          "Solnet.Wallet": "0.4.17"
         }
       },
       "solnet.metaplex": {
@@ -166,10 +167,10 @@
           "Microsoft.Extensions.Logging": "5.0.0",
           "Microsoft.Extensions.Logging.Abstractions": "5.0.0",
           "Microsoft.Extensions.Logging.Console": "5.0.0",
-          "Solnet.Keystore": "0.4.2",
-          "Solnet.Programs": "0.4.2",
-          "Solnet.Rpc": "0.4.2",
-          "Solnet.Wallet": "0.4.2"
+          "Solnet.Keystore": "0.4.17",
+          "Solnet.Programs": "0.4.17",
+          "Solnet.Rpc": "0.4.17",
+          "Solnet.Wallet": "0.4.17"
         }
       }
     }

--- a/Solnet.Metaplex.Test/Solnet.Metaplex.Test.csproj
+++ b/Solnet.Metaplex.Test/Solnet.Metaplex.Test.csproj
@@ -16,8 +16,9 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Solnet.Rpc" Version="0.4.2" />
-        <PackageReference Include="Solnet.Wallet" Version="0.4.2" />
+        <PackageReference Include="Solnet.Programs" Version="0.4.17" />
+        <PackageReference Include="Solnet.Rpc" Version="0.4.17" />
+        <PackageReference Include="Solnet.Wallet" Version="0.4.17" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Solnet.Metaplex/MetadataProgram.cs
+++ b/Solnet.Metaplex/MetadataProgram.cs
@@ -66,7 +66,7 @@ namespace Solnet.Metaplex
                 AccountMeta.ReadOnly(payerKey, true),
                 AccountMeta.ReadOnly(updateAuthority, updateAuthorityIsSigner),
                 AccountMeta.ReadOnly(SystemProgram.ProgramIdKey, false),
-                AccountMeta.ReadOnly(SystemProgram.SysVarRentKey, false)
+                AccountMeta.ReadOnly(SysVars.RentKey, false)
             };
 
 
@@ -210,7 +210,7 @@ namespace Solnet.Metaplex
                 AccountMeta.ReadOnly(metadataKey, false),
                 AccountMeta.ReadOnly(TokenProgram.ProgramIdKey, false),
                 AccountMeta.ReadOnly(SystemProgram.ProgramIdKey, false),
-                AccountMeta.ReadOnly(SystemProgram.SysVarRentKey, false)
+                AccountMeta.ReadOnly(SysVars.RentKey, false)
             };
 
             return new TransactionInstruction
@@ -273,7 +273,7 @@ namespace Solnet.Metaplex
 
                 AccountMeta.ReadOnly(TokenProgram.ProgramIdKey, false),
                 AccountMeta.ReadOnly(SystemProgram.ProgramIdKey, false),
-                AccountMeta.ReadOnly(SystemProgram.SysVarRentKey, false)
+                AccountMeta.ReadOnly(SysVars.RentKey, false)
             };
 
 

--- a/Solnet.Metaplex/Solnet.Metaplex.csproj
+++ b/Solnet.Metaplex/Solnet.Metaplex.csproj
@@ -21,10 +21,10 @@
         <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0.0" />
-        <PackageReference Include="Solnet.Keystore" Version="0.4.2" />
-        <PackageReference Include="Solnet.Programs" Version="0.4.2" />
-        <PackageReference Include="Solnet.Rpc" Version="0.4.2" />
-        <PackageReference Include="Solnet.Wallet" Version="0.4.2" />
+        <PackageReference Include="Solnet.Keystore" Version="0.4.17" />
+        <PackageReference Include="Solnet.Programs" Version="0.4.17" />
+        <PackageReference Include="Solnet.Rpc" Version="0.4.17" />
+        <PackageReference Include="Solnet.Wallet" Version="0.4.17" />
     </ItemGroup>
 
     <Import Project="..\SharedBuildProperties.props" />

--- a/Solnet.Metaplex/VaultProgram.cs
+++ b/Solnet.Metaplex/VaultProgram.cs
@@ -54,7 +54,7 @@ namespace Solnet.Metaplex
                 AccountMeta.ReadOnly( VaultAuthority, false),
                 AccountMeta.ReadOnly( PriceLookupAddress, false),
                 AccountMeta.ReadOnly( TokenProgram.ProgramIdKey, false),
-                AccountMeta.ReadOnly( SystemProgram.SysVarRentKey, false)
+                AccountMeta.ReadOnly( SysVars.RentKey, false)
             };
 
             return new TransactionInstruction{
@@ -99,8 +99,8 @@ namespace Solnet.Metaplex
                 AccountMeta.ReadOnly( Payer, true),
                 AccountMeta.ReadOnly( TransferAuthority, true),
                 AccountMeta.ReadOnly( TokenProgram.ProgramIdKey, false),
-                AccountMeta.ReadOnly( SystemProgram.SysVarRentKey, false),
-                AccountMeta.ReadOnly( SystemProgram.SysVarRentKey , false)
+                AccountMeta.ReadOnly( SysVars.RentKey, false),
+                AccountMeta.ReadOnly( SysVars.RentKey, false)
             };
 
             return new TransactionInstruction{

--- a/Solnet.Metaplex/packages.lock.json
+++ b/Solnet.Metaplex/packages.lock.json
@@ -37,40 +37,40 @@
       },
       "Solnet.KeyStore": {
         "type": "Direct",
-        "requested": "[0.4.2, )",
-        "resolved": "0.4.2",
-        "contentHash": "WIg/2YjcSmeJ3W41up1N12iyBrhc6nYq0aRoBGi3BJ5EQdSn/x8r3tE663rqDqU8ydi0IzfUgHXZd638nSLgVg==",
+        "requested": "[0.4.17, )",
+        "resolved": "0.4.17",
+        "contentHash": "89w1PKk0e9Glzt/dW1vPfoH2utVINdi3+9875+Qh2tpC8iVEeNlGr7tJCY4J5WF8Ht9vCqcuEu1qJ55Mf+myKg==",
         "dependencies": {
           "Chaos.NaCl.Standard": "1.0.0",
           "Portable.BouncyCastle": "1.8.2",
-          "Solnet.Wallet": "0.4.2"
+          "Solnet.Wallet": "0.4.17"
         }
       },
       "Solnet.Programs": {
         "type": "Direct",
-        "requested": "[0.4.2, )",
-        "resolved": "0.4.2",
-        "contentHash": "931jvjXMKjnDPZiKzLhdBRnt3miDu128HJ6Sqw0mIPZ8MXXdtKJ4KVz8SdU3iEi2oBrhc77Le7yJn1BJGWVVxg==",
+        "requested": "[0.4.17, )",
+        "resolved": "0.4.17",
+        "contentHash": "uGfOM5zcE2uTTOHFaWiOj1fee/fi+QjgeTc57ETPPNIvkkm4i8PFZJ0HFdfehLNk1uDd2H277ua/ZJdFXwIz3w==",
         "dependencies": {
-          "Solnet.Rpc": "0.4.2"
+          "Solnet.Rpc": "0.4.17"
         }
       },
       "Solnet.Rpc": {
         "type": "Direct",
-        "requested": "[0.4.2, )",
-        "resolved": "0.4.2",
-        "contentHash": "55qQqaXmtFyBIGBJ/VaLqkxJSDTFAHEF6lMMWGpIV6p7EV99TTBSUtE2zFmDtImD8YkplocCIpwU7kWGdqLzAA==",
+        "requested": "[0.4.17, )",
+        "resolved": "0.4.17",
+        "contentHash": "wrcafmjYq2wUWIzH2e0kRG4+ANy05G+IzuN0/Ka9+4vXtsgv59c1ZozCHlULEER50/deQo0UjIcRcjgaqh7OsA==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "5.0.0",
           "Microsoft.Extensions.Logging.Console": "5.0.0",
-          "Solnet.Wallet": "0.4.2"
+          "Solnet.Wallet": "0.4.17"
         }
       },
       "Solnet.Wallet": {
         "type": "Direct",
-        "requested": "[0.4.2, )",
-        "resolved": "0.4.2",
-        "contentHash": "YHgndl6T6z4UTM6OYglIFqIj6zOJWbCaJGiILDA46LFnA0nIiWdqZM4yNucS2dI1P6fhkBTk7gnBRHlIS3RteA==",
+        "requested": "[0.4.17, )",
+        "resolved": "0.4.17",
+        "contentHash": "v/jzBQU52j7Vz9M6wOJlsShl5GUfea0lgt13T+dlbknFe07lceNScAv3uYRxR1cUQWuhIqsRNquLGp3VyhaJ3w==",
         "dependencies": {
           "Chaos.NaCl.Standard": "1.0.0",
           "Portable.BouncyCastle": "1.8.2"


### PR DESCRIPTION

| Status  | Type  | ⚠️ Core Change | Issue |
| Ready  | Hotfix | Yes | Issue#26 |

Fixed issue retrieving rent key public key constant when updating dependencies to SOL.NET 4.17 from 4.2

It was referencing the old SystemProgram class when it should of been referencing the new SysVars class

All SOL.NET dependencies have been updated to 4.17 from 4.2