### PR TITLE
Patched Omni-Create instruction when creating master edition NFTs

### DIFF
--- a/Solnet.Metaplex.Examples/ExampleExplorer.cs
+++ b/Solnet.Metaplex.Examples/ExampleExplorer.cs
@@ -30,6 +30,7 @@ namespace Solnet.Metaplex.Examples
                     var example = (IRunnableExample)t.GetConstructor(Type.EmptyTypes).Invoke(null);
 
                     example.Run();
+                    
                 }
                 else
                 {

--- a/Solnet.Metaplex.Examples/GetMetadata.cs
+++ b/Solnet.Metaplex.Examples/GetMetadata.cs
@@ -3,6 +3,7 @@ using Solnet.Wallet;
 using Solnet.Rpc;
 using System;
 using Solnet.Metaplex.NFT.Library;
+using System.Threading.Tasks;
 
 namespace Solnet.Metaplex.Examples
 {
@@ -11,7 +12,7 @@ namespace Solnet.Metaplex.Examples
 public class GetMetadataExample : IRunnableExample
 {
     string pk = "5CEeeHkyezrVpexdKjGkMv18dDRRW2tbF45yr5YfmAHt";
-    public async void Run()
+    public async Task Run()
     {
         Console.WriteLine("### Get Metadata example ###");
         Console.WriteLine("Getting account {0}", pk );

--- a/Solnet.Metaplex.Examples/IRunnableExample.cs
+++ b/Solnet.Metaplex.Examples/IRunnableExample.cs
@@ -1,3 +1,5 @@
+using System.Threading.Tasks;
+
 namespace Solnet.Metaplex.Examples
 {
     /// <summary>
@@ -8,6 +10,6 @@ namespace Solnet.Metaplex.Examples
         /// <summary>
         /// Run the example.
         /// </summary>
-        void Run();
+        Task Run();
     }
 }

--- a/Solnet.Metaplex.Examples/MetadataCreate.cs
+++ b/Solnet.Metaplex.Examples/MetadataCreate.cs
@@ -8,6 +8,7 @@ using System.Text;
 using Solnet.Rpc.Utilities;
 using Solnet.Metaplex.NFT.Library;
 using Solnet.Metaplex.NFT;
+using System.Threading.Tasks;
 
 namespace Solnet.Metaplex.Examples
 {
@@ -21,10 +22,10 @@ namespace Solnet.Metaplex.Examples
         /// <summary>
         /// Run the example.
         /// </summary>
-        public async void Run() 
+        public async Task Run() 
         {
-
-            var client = ClientFactory.GetClient( Cluster.DevNet);
+            //Get a RPC provider link from QuickNode or use a public one provided by a community -- The default clusters are only for lite testing
+            var client = ClientFactory.GetClient( Cluster.MainNet);
             var exampleWallet = new Wallet.Wallet(pk);
 
             //Get your account either by the wallet or directly from the private key
@@ -54,7 +55,7 @@ namespace Solnet.Metaplex.Examples
                 //If your NFT has a parent collection NFT. You can specify it here
                 //collection = new Collection(collectionAddress),
 
-                uses = new Uses(UseMethod.Single, 5, 5),
+                //uses = new Uses(UseMethod.Single, 5, 5),
 
                 //If your NFT is programmable and has a ruleset then specify it here
                 //programmableConfig = new ProgrammableConfig(rulesetAddress)
@@ -63,7 +64,9 @@ namespace Solnet.Metaplex.Examples
             //Easily create any type of metadata token. Any nullable parameters can be overrided to provide the data needed to create complex metadata tokens or use legacy instructions
             MetadataClient metaplexClient = new MetadataClient(client);
            
-            await metaplexClient.CreateNFT(ownerAccount, mintAccount, TokenStandard.NonFungible, tokenMetadata, false, true);
+           var tx = await metaplexClient.CreateNFT(ownerAccount, mintAccount, TokenStandard.NonFungible, tokenMetadata, false, true);
+            Console.WriteLine(tx.RawRpcResponse);
+            Console.ReadKey();
         }
 
     }

--- a/Solnet.Metaplex/Metadata Program/MetadataClient.cs
+++ b/Solnet.Metaplex/Metadata Program/MetadataClient.cs
@@ -7,6 +7,7 @@ using Solnet.Rpc.Core.Http;
 using Solnet.Rpc.Messages;
 using Solnet.Rpc.Models;
 using Solnet.Wallet;
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
@@ -75,7 +76,7 @@ namespace Solnet.Metaplex.NFT
             {
                 Authority = _Authority;
             }
-            if (UpdateAuthority != _UpdateAuthority && _UpdateAuthority != null)
+            if (_UpdateAuthority != null && UpdateAuthority.PublicKey != _UpdateAuthority)
             {
                 UpdateAuthority = _UpdateAuthority;
 
@@ -92,7 +93,7 @@ namespace Solnet.Metaplex.NFT
 
 
             ulong minBalanceForExemptionMint = (await RpcClient.GetMinimumBalanceForRentExemptionAsync(TokenProgram.MintAccountDataSize)).Result;
-            TransactionInstruction NFTmetadata_instruction = MetadataProgram.CreateMetadataAccount(metadataAddress, mintAccount.PublicKey, Authority, PayerAddress, UpdateAuthority, metaData, tokenStandard, isMutable, UpdateAuthorityIsSigner, masterEditionAddress, maxSupply, collectionDetails);
+            TransactionInstruction NFTmetadata_instruction = MetadataProgram.CreateMetadataAccount(metadataAddress, mintAccount.PublicKey, Authority, PayerAddress, UpdateAuthority.PublicKey, metaData, tokenStandard, isMutable, UpdateAuthorityIsSigner, masterEditionAddress, maxSupply, collectionDetails);
             TransactionInstruction mintPNFT = MetadataProgram.Mint(AssociatedTokenAccountProgram.DeriveAssociatedTokenAccount(ownerAccount, mintAccount), metadataAddress, masterEditionAddress, mintAccount, Authority, PayerAddress, delegateRecord, tokenRecord, ownerAccount, rulesetAddress, 1);
             RequestResult<ResponseValue<LatestBlockHash>> blockHash = await RpcClient.GetLatestBlockHashAsync();
             if (metadataVersion == MetadataVersion.V4)
@@ -108,6 +109,7 @@ namespace Solnet.Metaplex.NFT
                 Build(Signers);
 
                 var tx = await RpcClient.SendTransactionAsync(OmniCreateMintInstruction);
+                Console.WriteLine(tx.RawRpcResponse);
                 return tx;
             }
             else

--- a/Solnet.Metaplex/Metadata Program/MetadataProgram.cs
+++ b/Solnet.Metaplex/Metadata Program/MetadataProgram.cs
@@ -51,9 +51,9 @@ namespace Solnet.Metaplex.NFT.Library
         {
             List<AccountMeta> _keys = new();
 
-            AccountMeta masterEditionMeta = AccountMeta.ReadOnly(MetadataProgram.ProgramIdKey, false);
+            AccountMeta masterEditionMeta = AccountMeta.Writable(MetadataProgram.ProgramIdKey, false);
             if (masterEditionKey != null)
-                masterEditionMeta = AccountMeta.ReadOnly(masterEditionKey, false);
+                masterEditionMeta = AccountMeta.Writable(masterEditionKey, false);
 
             List<AccountMeta> OmniKeys = new()
             {


### PR DESCRIPTION
Omni-create instruction had the master edition key as read only when it should of been writable causing cross-invocation violation  exception when trying to mint.
