### PR TITLE
Corrected metadata account parsing

### DIFF
--- a/Solnet.Metaplex/Metadata Program/Types/MetadataPacketLayout.cs
+++ b/Solnet.Metaplex/Metadata Program/Types/MetadataPacketLayout.cs
@@ -32,11 +32,11 @@ namespace Solnet.Metaplex.NFT.Library
         /// <summary>
         /// Creator Stream Position
         /// </summary>
-        public const int creatorSwitchOffset = 320;
+        public const int creatorSwitchOffset = 321;
         /// <summary>
         /// Creators Count Stream Position
         /// </summary>
-        public const int creatorsCountOffset = 321;
+        public const int creatorsCountOffset = 322;
 
         //Anything beyond this point is dynamically determined based on data provided
     }

--- a/Solnet.Metaplex/Metadata Program/Types/MetadataTypes.cs
+++ b/Solnet.Metaplex/Metadata Program/Types/MetadataTypes.cs
@@ -269,6 +269,7 @@ namespace Solnet.Metaplex.NFT.Library
             editionNonce = _editionNonce;
             tokenStandard = _tokenStandard;
             programmableConfig = programmableconfig;
+            hasCreators = _creators?.Count > 0;
         }
     }
 


### PR DESCRIPTION
## Problem

Onchain metadata parsing doesn't work correctly. I opted to just fix it instead of opening an issue.

It does not parse the creator array correctly, due to the offset for the option enum byte being parsed from the last byte of the seller fee basis points (320 != 321) - and everything being offset from getting the creator count from the option byte. Currently, it can never correctly parse creator count, ProgrammableConfig, edition nonce, uses, mutability, or collection for Metadata accounts with more than one creator, and can't parse most of the fields from an account with a single creator.

## Solution

Corrected on-chain metadata parsing such that it parses the account in accordance with the metadata program, and added a reference to the accountInfo in the relevant field. 
Creators count is still parsed as an u8, for convenience, as it doesn't make a difference for a maximum number of creators that will not exceed a byte.

**BEFORE**:
<img width="633" alt="Screenshot 2023-05-11 at 18 40 31" src="https://github.com/bmresearch/Solnet.Metaplex/assets/92829333/fe3bd779-4e6c-4902-a45c-d4e521d8b947">


**AFTER**:
<img width="700" alt="Screenshot 2023-05-11 at 18 49 19" src="https://github.com/bmresearch/Solnet.Metaplex/assets/92829333/1c6b3849-f931-43a5-98b9-daa4dfe7cb24">

