### PR TITLE
Fixed build error from latest creators offset patch

### DIFF
--- a/Solnet.Metaplex/Metadata Program/Account/MetadataAccount.cs
+++ b/Solnet.Metaplex/Metadata Program/Account/MetadataAccount.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net.Http;
+using System.Numerics;
 using System.Text;
 using System.Threading.Tasks;
 


### PR DESCRIPTION
Latest patch to the creator offset in metadata account class was missing the System.Numerics dependency in the script causing a failed build in the pipeline.

Both small patches has been implemented in the nuget package release v6.8.2