### PR TITLE
Metaplex Core 0.6.1 Integration

### DIFF
--- a/Solnet.Metaplex.Examples/Solnet.Metaplex.Examples.csproj
+++ b/Solnet.Metaplex.Examples/Solnet.Metaplex.Examples.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <RootNamespace>Solnet.Metaplex.Examples</RootNamespace>
     </PropertyGroup>
 

--- a/Solnet.Metaplex.Examples/packages.lock.json
+++ b/Solnet.Metaplex.Examples/packages.lock.json
@@ -160,24 +160,31 @@
         "resolved": "1.9.0",
         "contentHash": "eZZBCABzVOek+id9Xy04HhmgykF0wZg9wpByzrWN7q8qEI0Qen9b7tfd7w8VA3dOeesumMG7C5ZPy0jk7PSRHw=="
       },
-      "Solnet.Extensions": {
+      "Solana.Programs": {
         "type": "Transitive",
-        "resolved": "6.1.0",
-        "contentHash": "jTs3CNeA1/FSdDBMDy/MfrTx8Z3pBc9qMRFDC2lgkW8SwHfL9LG0tso/BYsckEKXPpODUxe08xCrCWtLg/Hw1Q==",
+        "resolved": "8.3.0",
+        "contentHash": "hIyt1AkPRFLRkDRsYuNS8mwkQSIO6Ji2/mudONLwcQ+ILTqGM4iEMUP6BjzStInyookX10HZX0nKS76mkzhgiw==",
         "dependencies": {
-          "Solnet.Programs": "6.1.0",
-          "Solnet.Rpc": "6.1.0",
-          "Solnet.Wallet": "6.1.0"
+          "Solana.Rpc": "8.3.0"
         }
       },
-      "Solnet.KeyStore": {
+      "Solana.Rpc": {
         "type": "Transitive",
-        "resolved": "6.1.0",
-        "contentHash": "CkFUXyWLahJh5KeRLNd2BqEFaeosGNhsPmmrZY9yUM92H/4hvNnw84J1RWIbw5nfsczNMp8iYf4l265+sZcKTA==",
+        "resolved": "8.3.0",
+        "contentHash": "1GDMxsgHmpW93NyQ9+KzQVuu+UIngEiZhaVDzXPUyD+QRsMC+fNOoxI0K5V1nCcJEv+204V9aUgUhoaB978WIg==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "6.0.0",
+          "Microsoft.Extensions.Logging.Console": "6.0.0",
+          "Solana.Wallet": "8.3.0"
+        }
+      },
+      "Solana.Wallet": {
+        "type": "Transitive",
+        "resolved": "8.3.0",
+        "contentHash": "KWCybD7wcnOM8NIUxnjn/QYY487Fevv2cvJhA27bFWeux0I5ThEbXBXMQuZ5YVc4VKRRpy+ULXfuoL6M83kASg==",
         "dependencies": {
           "Chaos.NaCl.Standard": "1.0.0",
-          "Portable.BouncyCastle": "1.9.0",
-          "Solnet.Wallet": "6.1.0"
+          "Portable.BouncyCastle": "1.9.0"
         }
       },
       "System.Diagnostics.DiagnosticSource": {
@@ -217,11 +224,9 @@
           "Microsoft.Extensions.Logging.Abstractions": "[6.0.2, )",
           "Microsoft.Extensions.Logging.Console": "[6.0.0, )",
           "Newtonsoft.Json": "[13.0.1, )",
-          "Solnet.Extensions": "[6.1.0, )",
-          "Solnet.Keystore": "[6.1.0, )",
-          "Solnet.Programs": "[6.1.0, )",
-          "Solnet.Rpc": "[6.1.0, )",
-          "Solnet.Wallet": "[6.1.0, )"
+          "Solana.Programs": "[8.3.0, )",
+          "Solana.Rpc": "[8.3.0, )",
+          "Solana.Wallet": "[8.3.0, )"
         }
       }
     }

--- a/Solnet.Metaplex.Examples/packages.lock.json
+++ b/Solnet.Metaplex.Examples/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0": {
+    "net8.0": {
       "Solnet.Programs": {
         "type": "Direct",
         "requested": "[6.1.0, )",

--- a/Solnet.Metaplex/Core Program/MplCoreAccounts.cs
+++ b/Solnet.Metaplex/Core Program/MplCoreAccounts.cs
@@ -1,0 +1,158 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+using Solnet.Metaplex.Core;
+using Solnet.Programs.Utilities;
+using Solnet.Wallet;
+using Solnet.Metaplex.Core.Types;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Solnet.Metaplex.Core.Accounts
+{
+    public partial class PluginHeaderV1
+    {
+        public Key Key { get; set; }
+
+        public ulong PluginRegistryOffset { get; set; }
+
+        public static PluginHeaderV1 Deserialize(ReadOnlySpan<byte> _data)
+        {
+            int offset = 0;
+            PluginHeaderV1 result = new PluginHeaderV1();
+            result.Key = (Key)_data.GetU8(offset);
+            offset += 1;
+            result.PluginRegistryOffset = _data.GetU64(offset);
+            offset += 8;
+            return result;
+        }
+    }
+
+    public partial class PluginRegistryV1
+    {
+        public Key Key { get; set; }
+
+        public RegistryRecord[] Registry { get; set; }
+
+        public ExternalPluginRecord[] ExternalPlugins { get; set; }
+
+        public static PluginRegistryV1 Deserialize(ReadOnlySpan<byte> _data)
+        {
+            int offset = 0;
+            PluginRegistryV1 result = new PluginRegistryV1();
+            result.Key = (Key)_data.GetU8(offset);
+            offset += 1;
+            int resultRegistryLength = (int)_data.GetU32(offset);
+            offset += 4;
+            result.Registry = new RegistryRecord[resultRegistryLength];
+            for (uint resultRegistryIdx = 0; resultRegistryIdx < resultRegistryLength; resultRegistryIdx++)
+            {
+                offset += RegistryRecord.Deserialize(_data, offset, out var resultRegistryresultRegistryIdx);
+                result.Registry[resultRegistryIdx] = resultRegistryresultRegistryIdx;
+            }
+
+            int resultExternalPluginsLength = (int)_data.GetU32(offset);
+            offset += 4;
+            result.ExternalPlugins = new ExternalPluginRecord[resultExternalPluginsLength];
+            for (uint resultExternalPluginsIdx = 0; resultExternalPluginsIdx < resultExternalPluginsLength; resultExternalPluginsIdx++)
+            {
+                offset += ExternalPluginRecord.Deserialize(_data, offset, out var resultExternalPluginsresultExternalPluginsIdx);
+                result.ExternalPlugins[resultExternalPluginsIdx] = resultExternalPluginsresultExternalPluginsIdx;
+            }
+
+            return result;
+        }
+    }
+
+    public partial class AssetV1
+    {
+        public Key Key { get; set; }
+
+        public PublicKey Owner { get; set; }
+
+        public PublicKey UpdateAuthority { get; set; }
+
+        public string Name { get; set; }
+
+        public string Uri { get; set; }
+
+        public ulong? Seq { get; set; }
+
+        public static AssetV1 Deserialize(ReadOnlySpan<byte> _data)
+        {
+            int offset = 0;
+            AssetV1 result = new AssetV1();
+            result.Key = (Key)_data.GetU8(offset);
+            offset += 1;
+            result.Owner = _data.GetPubKey(offset);
+            offset += 32;
+            offset += 1;
+            result.UpdateAuthority = _data.GetPubKey(offset);
+            offset += 32;
+            offset += _data.GetBorshString(offset, out var resultName);
+            result.Name = resultName;
+            offset += _data.GetBorshString(offset, out var resultUri);
+            result.Uri = resultUri;
+            if (_data.GetBool(offset++))
+            {
+                result.Seq = _data.GetU64(offset);
+                offset += 8;
+            }
+
+            return result;
+        }
+    }
+
+    public partial class CollectionV1
+    {
+        public Key Key { get; set; }
+
+        public PublicKey UpdateAuthority { get; set; }
+
+        public string Name { get; set; }
+
+        public string Uri { get; set; }
+
+        public uint NumMinted { get; set; }
+
+        public uint CurrentSize { get; set; }
+
+        public static CollectionV1 Deserialize(ReadOnlySpan<byte> _data)
+        {
+            int offset = 0;
+            CollectionV1 result = new CollectionV1();
+            result.Key = (Key)_data.GetU8(offset);
+            offset += 1;
+            result.UpdateAuthority = _data.GetPubKey(offset);
+            offset += 32;
+            offset += _data.GetBorshString(offset, out var resultName);
+            result.Name = resultName;
+            offset += _data.GetBorshString(offset, out var resultUri);
+            result.Uri = resultUri;
+            result.NumMinted = _data.GetU32(offset);
+            offset += 4;
+            result.CurrentSize = _data.GetU32(offset);
+            offset += 4;
+            return result;
+        }
+    }
+
+    public partial class HashedAssetV1
+    {
+        public Key Key { get; set; }
+
+        public byte[] Hash { get; set; }
+
+        public static HashedAssetV1 Deserialize(ReadOnlySpan<byte> _data)
+        {
+            int offset = 0;
+            HashedAssetV1 result = new HashedAssetV1();
+            result.Key = (Key)_data.GetU8(offset);
+            offset += 1;
+            result.Hash = _data.GetBytes(offset, 32);
+            offset += 32;
+            return result;
+        }
+    }
+}

--- a/Solnet.Metaplex/Core Program/MplCoreClient.cs
+++ b/Solnet.Metaplex/Core Program/MplCoreClient.cs
@@ -36,13 +36,17 @@ namespace Solnet.Metaplex.Core
         /// <param name="signers"></param>
         /// <param name="feePayer"></param>
         /// <param name="transactionInstruction"></param>
+        /// <param name="computebudget"></param>
+        /// <param name="computeprice"></param>
         /// <returns></returns>
-        public async Task<RequestResult<string>> SendMetaplexTransaction(Account[] signers, PublicKey feePayer, TransactionInstruction transactionInstruction)
+        public async Task<RequestResult<string>> SendMetaplexTransaction(Account[] signers, PublicKey feePayer, TransactionInstruction transactionInstruction, ulong computebudget = 100000, ulong computeprice = 10000)
         {
             RequestResult<ResponseValue<LatestBlockHash>> blockHash = await RpcClient.GetLatestBlockHashAsync();
             byte[] Transaction = new TransactionBuilder().
                 SetRecentBlockHash(blockHash.Result.Value.Blockhash).
                 SetFeePayer(feePayer).
+                AddInstruction(ComputeBudgetProgram.SetComputeUnitLimit((uint)computebudget)).
+                AddInstruction(ComputeBudgetProgram.SetComputeUnitPrice(computeprice)).
                 AddInstruction(transactionInstruction).
                 Build(signers);
 
@@ -218,14 +222,39 @@ namespace Solnet.Metaplex.Core
         /// <param name="signers"></param>
         /// <param name="accounts"></param>
         /// <param name="createV1Args"></param>
+        /// <param name="computebudget"></param>
+        /// <param name="computeprice"></param>
         /// <returns></returns>
-        public async Task<RequestResult<string>> CreateV1Async(Account[] signers, CreateV1Accounts accounts, CreateV1Args createV1Args)
+        public async Task<RequestResult<string>> CreateNFTAsync(Account[] signers, CreateV1Accounts accounts, CreateV1Args createV1Args, ulong computebudget = 200000, ulong computeprice = 10000)
         {
             TransactionInstruction metaplex_create_instruction = MplCoreProgram.CreateV1(accounts, createV1Args);
-            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_create_instruction);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_create_instruction, computebudget, computeprice);
         }
 
-
+        /// <summary>
+        /// Create Metaplex Core NFTs
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="asset"></param>
+        /// <param name="authority"></param>
+        /// <param name="owner"></param>
+        /// <param name="feepayer"></param>
+        /// <param name="createV1Args"></param>
+        /// <param name="computebudget"></param>
+        /// <param name="computeprice"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> CreateNFTAsync(Account[] signers, PublicKey asset, PublicKey authority, PublicKey owner, PublicKey feepayer,  CreateV1Args createV1Args, ulong computebudget = 100000, ulong computeprice = 10000)
+        {
+            CreateV1Accounts accounts = new CreateV1Accounts
+            {
+                Asset = asset,
+                Authority = authority,
+                Owner = owner,
+                Payer = feepayer,
+            };
+            TransactionInstruction metaplex_create_instruction = MplCoreProgram.CreateV1(accounts, createV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_create_instruction, computebudget, computeprice);
+        }
 
         /// <summary>
         /// Create Metaplex Core Collections
@@ -403,7 +432,7 @@ namespace Solnet.Metaplex.Core
         /// <param name="accounts"></param>
         /// <param name="updateV1Args"></param>
         /// <returns></returns>
-        public async Task<RequestResult<string>> UpdateV1Async(Account[] signers, UpdateV1Accounts accounts, UpdateV1Args updateV1Args)
+        public async Task<RequestResult<string>> UpdateNFTAsync(Account[] signers, UpdateV1Accounts accounts, UpdateV1Args updateV1Args)
        {
            TransactionInstruction metaplex_instruction = MplCoreProgram.UpdateV1(accounts, updateV1Args);
             return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
@@ -427,10 +456,10 @@ namespace Solnet.Metaplex.Core
         /// <param name="accounts"></param>
         /// <param name="compressV1Args"></param>
         /// <returns></returns>
-        public async Task<RequestResult<string>> CompressV1Async(Account[] signers, CompressV1Accounts accounts, CompressV1Args compressV1Args)
+        public async Task<RequestResult<string>> CompressNFTAsync(Account[] signers, CompressV1Accounts accounts, CompressV1Args compressV1Args, ulong computebudget = 200000, ulong computeprice = 10000)
        {
            TransactionInstruction metaplex_instruction = MplCoreProgram.CompressV1(accounts, compressV1Args);
-            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction, computebudget, computeprice);
         }
         /// <summary>
         /// Decompress Metaplex Core Asset

--- a/Solnet.Metaplex/Core Program/MplCoreClient.cs
+++ b/Solnet.Metaplex/Core Program/MplCoreClient.cs
@@ -1,0 +1,461 @@
+﻿
+using Solnet.Metaplex.Core.Accounts;
+using Solnet.Programs.Abstract;
+using Solnet.Rpc.Models;
+using Solnet.Rpc;
+using Solnet.Rpc.Core.Http;
+using Solnet.Wallet;
+using Solnet.Programs.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Solnet.Rpc.Types;
+using Solnet.Metaplex.Core.Models;
+using Solnet.Metaplex.Core.Types;
+using Solnet.Programs;
+using Solnet.Rpc.Builders;
+using Solnet.Rpc.Messages;
+using Solnet.Wallet.Utilities;
+#pragma warning disable CS1591 
+
+namespace Solnet.Metaplex.Core
+{
+    public partial class MplCoreClient
+    {
+        public IRpcClient RpcClient { get; set; }
+        public MplCoreClient(IRpcClient rpcClient)
+        {
+            RpcClient = rpcClient;
+        }
+
+        /// <summary>
+        /// Builds the metaplex transaction, signs it then sends it to the RPC
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="feePayer"></param>
+        /// <param name="transactionInstruction"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> SendMetaplexTransaction(Account[] signers, PublicKey feePayer, TransactionInstruction transactionInstruction)
+        {
+            RequestResult<ResponseValue<LatestBlockHash>> blockHash = await RpcClient.GetLatestBlockHashAsync();
+            byte[] Transaction = new TransactionBuilder().
+                SetRecentBlockHash(blockHash.Result.Value.Blockhash).
+                SetFeePayer(feePayer).
+                AddInstruction(transactionInstruction).
+                Build(signers);
+
+           return await RpcClient.SendTransactionAsync(Transaction);
+        }
+
+        /// <summary>
+        /// Derive all plugin header accounts owned by the Metaplex Core program
+        /// </summary>
+        /// <param name="programAddress"></param>
+        /// <param name="commitment"></param>
+        /// <returns></returns>
+        public async Task<ProgramAccountsResultWrapper<List<PluginHeaderV1>>> GetPluginHeaderV1sAsync(string programAddress, Commitment commitment = Commitment.Finalized)
+        {
+            byte[] bytes = { (byte)3 };
+            var b58 = new Base58Encoder();
+            var list = new List<MemCmp> { new MemCmp { Bytes = b58.EncodeData(bytes), Offset = 0 } };
+            var res = await RpcClient.GetProgramAccountsAsync(programAddress, commitment, memCmpList: list);
+            if (!res.WasSuccessful || !(res.Result?.Count > 0))
+                return new ProgramAccountsResultWrapper<List<PluginHeaderV1>>(res);
+            List<PluginHeaderV1> resultingAccounts = new List<PluginHeaderV1>(res.Result.Count);
+            resultingAccounts.AddRange(res.Result.Select(result => PluginHeaderV1.Deserialize(Convert.FromBase64String(result.Account.Data[0]))));
+            return new ProgramAccountsResultWrapper<List<PluginHeaderV1>>(res, resultingAccounts);
+        }
+        /// <summary>
+        /// Derive all plugin registry accounts owned by the Metaplex Core program
+        /// </summary>
+        /// <param name="programAddress"></param>
+        /// <param name="commitment"></param>
+        /// <returns></returns>
+        public async Task<ProgramAccountsResultWrapper<List<PluginRegistryV1>>> GetPluginRegistryV1sAsync(string programAddress, Commitment commitment = Commitment.Finalized)
+        {
+            byte[] bytes = { (byte)4 };
+            var b58 = new Base58Encoder();
+            var list = new List<MemCmp> { new MemCmp { Bytes = b58.EncodeData(bytes), Offset = 0 } };
+            var res = await RpcClient.GetProgramAccountsAsync(programAddress, commitment, memCmpList: list);
+            if (!res.WasSuccessful || !(res.Result?.Count > 0))
+                return new ProgramAccountsResultWrapper<List<PluginRegistryV1>>(res);
+            List<PluginRegistryV1> resultingAccounts = new List<PluginRegistryV1>(res.Result.Count);
+            resultingAccounts.AddRange(res.Result.Select(result => PluginRegistryV1.Deserialize(Convert.FromBase64String(result.Account.Data[0]))));
+            return new ProgramAccountsResultWrapper<List<PluginRegistryV1>>(res, resultingAccounts);
+        }
+        /// <summary>
+        /// Derive all metadata accounts owned by the Metaplex Core program
+        /// </summary>
+        /// <param name="programAddress"></param>
+        /// <param name="commitment"></param>
+        /// <returns></returns>
+        public async Task<ProgramAccountsResultWrapper<List<AssetV1>>> GetAssetV1sAsync(string programAddress, Commitment commitment = Commitment.Finalized)
+        {
+            byte[] bytes = { (byte)1 };
+            var b58 = new Base58Encoder();
+            var list = new List<MemCmp> { new MemCmp { Bytes = b58.EncodeData(bytes) , Offset = 0 } };
+            var res = await RpcClient.GetProgramAccountsAsync(programAddress, commitment, memCmpList: list);
+            if (!res.WasSuccessful || !(res.Result?.Count > 0))
+                return new ProgramAccountsResultWrapper<List<AssetV1>>(res);
+            List<AssetV1> resultingAccounts = new List<AssetV1>(res.Result.Count);
+            resultingAccounts.AddRange(res.Result.Select(result => AssetV1.Deserialize(Convert.FromBase64String(result.Account.Data[0]))));
+            return new ProgramAccountsResultWrapper<List<AssetV1>>(res, resultingAccounts);
+        }
+        /// <summary>
+        /// Derive all collection accounts owned by the Metaplex Core program
+        /// </summary>
+        /// <param name="programAddress"></param>
+        /// <param name="commitment"></param>
+        /// <returns></returns>
+        public async Task<ProgramAccountsResultWrapper<List<CollectionV1>>> GetCollectionV1sAsync(string programAddress, Commitment commitment = Commitment.Finalized)
+        {
+            byte[] bytes = { (byte)5 };
+            var b58 = new Base58Encoder();
+            var list = new List<MemCmp> { new MemCmp { Bytes = b58.EncodeData(bytes), Offset = 0 } };
+            var res = await RpcClient.GetProgramAccountsAsync(programAddress, commitment, memCmpList: list);
+            if (!res.WasSuccessful || !(res.Result?.Count > 0))
+                return new ProgramAccountsResultWrapper<List<CollectionV1>>(res);
+            List<CollectionV1> resultingAccounts = new List<CollectionV1>(res.Result.Count);
+            resultingAccounts.AddRange(res.Result.Select(result => CollectionV1.Deserialize(Convert.FromBase64String(result.Account.Data[0]))));
+            return new ProgramAccountsResultWrapper<List<CollectionV1>>(res, resultingAccounts);
+        }
+        /// <summary>
+        /// Derive all hashed assets owned by the Metaplex Core program
+        /// </summary>
+        /// <param name="programAddress"></param>
+        /// <param name="commitment"></param>
+        /// <returns></returns>
+        public async Task<ProgramAccountsResultWrapper<List<HashedAssetV1>>> GetHashedAssetV1sAsync(string programAddress, Commitment commitment = Commitment.Finalized)
+        {
+            byte[] bytes = { (byte)2 };
+            var b58 = new Base58Encoder();
+            var list = new List<MemCmp> { new MemCmp { Bytes = b58.EncodeData(bytes), Offset = 0 } };
+            var res = await RpcClient.GetProgramAccountsAsync(programAddress, commitment, memCmpList: list);
+            Console.WriteLine(res.RawRpcResponse);
+            if (!res.WasSuccessful || !(res.Result?.Count > 0))
+                return new ProgramAccountsResultWrapper<List<HashedAssetV1>>(res);
+            List<HashedAssetV1> resultingAccounts = new List<HashedAssetV1>(res.Result.Count);
+            resultingAccounts.AddRange(res.Result.Select(result => HashedAssetV1.Deserialize(Convert.FromBase64String(result.Account.Data[0]))));
+            return new ProgramAccountsResultWrapper<List<HashedAssetV1>>(res, resultingAccounts);
+        }
+        /// <summary>
+        /// Derive all plugin header accounts owned by the Metaplex Core program
+        /// </summary>
+        /// <param name="accountAddress"></param>
+        /// <param name="commitment"></param>
+        /// <returns></returns>
+        public async Task<AccountResultWrapper<PluginHeaderV1>> GetPluginHeaderV1Async(string accountAddress, Commitment commitment = Commitment.Finalized)
+        {
+            var res = await RpcClient.GetAccountInfoAsync(accountAddress, commitment);
+            if (!res.WasSuccessful)
+                return new AccountResultWrapper<PluginHeaderV1>(res);
+            var resultingAccount = PluginHeaderV1.Deserialize(Convert.FromBase64String(res.Result.Value.Data[0]));
+            return new AccountResultWrapper<PluginHeaderV1>(res, resultingAccount);
+        }
+        /// <summary>
+        /// Derive all plugin registry accounts owned by the Metaplex Core program
+        /// </summary>
+        /// <param name="accountAddress"></param>
+        /// <param name="commitment"></param>
+        /// <returns></returns>
+        public async Task<AccountResultWrapper<PluginRegistryV1>> GetPluginRegistryV1Async(string accountAddress, Commitment commitment = Commitment.Finalized)
+        {
+            var res = await RpcClient.GetAccountInfoAsync(accountAddress, commitment);
+            if (!res.WasSuccessful)
+                return new AccountResultWrapper<PluginRegistryV1>(res);
+            var resultingAccount = PluginRegistryV1.Deserialize(Convert.FromBase64String(res.Result.Value.Data[0]));
+            return new AccountResultWrapper<PluginRegistryV1>(res, resultingAccount);
+        }
+        /// <summary>
+        /// Retrieve metadata from Metaplex Core asset
+        /// </summary>
+        /// <param name="accountAddress"></param>
+        /// <param name="commitment"></param>
+        /// <returns></returns>
+        public async Task<AccountResultWrapper<AssetV1>> GetAssetV1Async(string accountAddress, Commitment commitment = Commitment.Finalized)
+        {
+            var res = await RpcClient.GetAccountInfoAsync(accountAddress, commitment);
+            Console.WriteLine(res.RawRpcResponse);
+            if (!res.WasSuccessful)
+                return new AccountResultWrapper<AssetV1>(res);
+            var resultingAccount = AssetV1.Deserialize(Convert.FromBase64String(res.Result.Value.Data[0]));
+            return new AccountResultWrapper<AssetV1>(res, resultingAccount);
+        }
+        /// <summary>
+        /// Retrieve collection info from collection account
+        /// </summary>
+        /// <param name="accountAddress"></param>
+        /// <param name="commitment"></param>
+        /// <returns></returns>
+        public async Task<CollectionV1> GetCollectionV1Async(string accountAddress, Commitment commitment = Commitment.Finalized)
+        {
+            var res = await RpcClient.GetAccountInfoAsync(accountAddress, commitment);
+            if (!res.WasSuccessful)
+                return new CollectionV1();
+            var resultingAccount = CollectionV1.Deserialize(Convert.FromBase64String(res.Result.Value.Data[0]));
+            return resultingAccount;
+        }
+        /// <summary>
+        /// Retrieve metadata from hashed asset account
+        /// </summary>
+        /// <param name="accountAddress"></param>
+        /// <param name="commitment"></param>
+        /// <returns></returns>
+        public async Task<AccountResultWrapper<HashedAssetV1>> GetHashedAssetV1Async(string accountAddress, Commitment commitment = Commitment.Finalized)
+        {
+            var res = await RpcClient.GetAccountInfoAsync(accountAddress, commitment);
+            if (!res.WasSuccessful)
+                return new AccountResultWrapper<HashedAssetV1>(res);
+            var resultingAccount = HashedAssetV1.Deserialize(Convert.FromBase64String(res.Result.Value.Data[0]));
+            return new AccountResultWrapper<HashedAssetV1>(res, resultingAccount);
+        }
+
+        /// <summary>
+        /// Create Metaplex Core NFTs
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="createV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> CreateV1Async(Account[] signers, CreateV1Accounts accounts, CreateV1Args createV1Args)
+        {
+            TransactionInstruction metaplex_create_instruction = MplCoreProgram.CreateV1(accounts, createV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_create_instruction);
+        }
+
+
+
+        /// <summary>
+        /// Create Metaplex Core Collections
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="createCollectionV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> CreateCollectionV1Async(Account[] signers, CreateCollectionV1Accounts accounts, CreateCollectionV1Args createCollectionV1Args)
+       {
+            TransactionInstruction metaplex_instruction = MplCoreProgram.CreateCollectionV1(accounts, createCollectionV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Add Plugin to Metaplex Core Asset
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="addPluginV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> AddPluginV1Async(Account[] signers, AddPluginV1Accounts accounts, AddPluginV1Args addPluginV1Args)
+       {
+            TransactionInstruction metaplex_instruction = MplCoreProgram.AddPluginV1(accounts, addPluginV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Add Plugin to Metaplex Core collection account
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="addCollectionPluginV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> AddCollectionPluginV1Async(Account[] signers, AddCollectionPluginV1Accounts accounts, AddCollectionPluginV1Args addCollectionPluginV1Args)
+       {
+            TransactionInstruction metaplex_instruction = MplCoreProgram.AddCollectionPluginV1(accounts, addCollectionPluginV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Remove plugin from Metaplex Core assets
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="removePluginV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> RemovePluginV1Async(Account[] signers, RemovePluginV1Accounts accounts, RemovePluginV1Args removePluginV1Args)
+       {
+            TransactionInstruction metaplex_instruction =  MplCoreProgram.RemovePluginV1(accounts, removePluginV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Remove plugin from Metaplex Core collections
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="removeCollectionPluginV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> RemoveCollectionPluginV1Async(Account[] signers, RemoveCollectionPluginV1Accounts accounts, RemoveCollectionPluginV1Args removeCollectionPluginV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.RemoveCollectionPluginV1(accounts, removeCollectionPluginV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Update plugin associated with a Metaplex Core Asset
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="updatePluginV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> UpdatePluginV1Async(Account[] signers, UpdatePluginV1Accounts accounts, UpdatePluginV1Args updatePluginV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.UpdatePluginV1(accounts, updatePluginV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Update plugin associated with a Metaplex Core Collection
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="updateCollectionPluginV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> UpdateCollectionPluginV1Async(Account[] signers, UpdateCollectionPluginV1Accounts accounts, UpdateCollectionPluginV1Args updateCollectionPluginV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.UpdateCollectionPluginV1(accounts, updateCollectionPluginV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Approve plugin authority on a Metaplex Core Asset
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="approvePluginAuthorityV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> ApprovePluginAuthorityV1Async(Account[] signers, ApprovePluginAuthorityV1Accounts accounts, ApprovePluginAuthorityV1Args approvePluginAuthorityV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.ApprovePluginAuthorityV1(accounts, approvePluginAuthorityV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Approve plugin authority on a Metaplex Core Collection
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="approveCollectionPluginAuthorityV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> ApproveCollectionPluginAuthorityV1Async(Account[] signers, ApproveCollectionPluginAuthorityV1Accounts accounts, ApproveCollectionPluginAuthorityV1Args approveCollectionPluginAuthorityV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.ApproveCollectionPluginAuthorityV1(accounts, approveCollectionPluginAuthorityV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Revoke plugin authority on a Metaplex Core Asset
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="revokePluginAuthorityV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> RevokePluginAuthorityV1Async(Account[] signers, RevokePluginAuthorityV1Accounts accounts, RevokePluginAuthorityV1Args revokePluginAuthorityV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.RevokePluginAuthorityV1(accounts, revokePluginAuthorityV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Revoke plugin authority on a Metaplex Core Collection
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="revokeCollectionPluginAuthorityV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> RevokeCollectionPluginAuthorityV1Async(Account[] signers, RevokeCollectionPluginAuthorityV1Accounts accounts, RevokeCollectionPluginAuthorityV1Args revokeCollectionPluginAuthorityV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.RevokeCollectionPluginAuthorityV1(accounts, revokeCollectionPluginAuthorityV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Burn Metaplex Core Asset
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="burnV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> BurnV1Async(Account[] signers, BurnV1Accounts accounts, BurnV1Args burnV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.BurnV1(accounts, burnV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Burn Metaplex Core Collection
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="burnCollectionV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> BurnCollectionV1Async(Account[] signers, BurnCollectionV1Accounts accounts, BurnCollectionV1Args burnCollectionV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.BurnCollectionV1(accounts, burnCollectionV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Transfer Metaplex Core Asset
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="transferV1Args"></param>
+
+        /// <returns></returns>
+        public async Task<RequestResult<string>> TransferV1Async(Account[] signers, TransferV1Accounts accounts, TransferV1Args transferV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.TransferV1(accounts, transferV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Update Metaplex Core Asset
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="updateV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> UpdateV1Async(Account[] signers, UpdateV1Accounts accounts, UpdateV1Args updateV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.UpdateV1(accounts, updateV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Update Metaplex Core Collection
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="updateCollectionV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> UpdateCollectionV1Async(Account[] signers, UpdateCollectionV1Accounts accounts, UpdateCollectionV1Args updateCollectionV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.UpdateCollectionV1(accounts, updateCollectionV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Compress Metaplex Core Asset
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="compressV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> CompressV1Async(Account[] signers, CompressV1Accounts accounts, CompressV1Args compressV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.CompressV1(accounts, compressV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Decompress Metaplex Core Asset
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <param name="decompressV1Args"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> DecompressV1Async(Account[] signers, DecompressV1Accounts accounts, DecompressV1Args decompressV1Args)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.DecompressV1(accounts, decompressV1Args);
+            return await SendMetaplexTransaction(signers, accounts.Payer, metaplex_instruction);
+        }
+        /// <summary>
+        /// Collect --- Not totally sure what this does
+        /// </summary>
+        /// <param name="signers"></param>
+        /// <param name="accounts"></param>
+        /// <returns></returns>
+        public async Task<RequestResult<string>> CollectAsync(Account[] signers, CollectAccounts accounts)
+       {
+           TransactionInstruction metaplex_instruction = MplCoreProgram.Collect(accounts);
+            return await SendMetaplexTransaction(signers, signers[0], metaplex_instruction);
+        }
+     
+
+    }
+}

--- a/Solnet.Metaplex/Core Program/MplCoreErrors.cs
+++ b/Solnet.Metaplex/Core Program/MplCoreErrors.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+namespace Solnet.Metaplex.Core
+{
+    public enum MplCoreError : uint
+    {
+        InvalidSystemProgram = 0U,
+        DeserializationError = 1U,
+        SerializationError = 2U,
+        PluginsNotInitialized = 3U,
+        PluginNotFound = 4U,
+        NumericalOverflow = 5U,
+        IncorrectAccount = 6U,
+        IncorrectAssetHash = 7U,
+        InvalidPlugin = 8U,
+        InvalidAuthority = 9U,
+        AssetIsFrozen = 10U,
+        MissingCompressionProof = 11U,
+        CannotMigrateMasterWithSupply = 12U,
+        CannotMigratePrints = 13U,
+        CannotBurnCollection = 14U,
+        PluginAlreadyExists = 15U,
+        NumericalOverflowError = 16U,
+        AlreadyCompressed = 17U,
+        AlreadyDecompressed = 18U,
+        InvalidCollection = 19U,
+        MissingUpdateAuthority = 20U,
+        MissingNewOwner = 21U,
+        MissingSystemProgram = 22U,
+        NotAvailable = 23U,
+        InvalidAsset = 24U,
+        MissingCollection = 25U,
+        NoApprovals = 26U,
+        CannotRedelegate = 27U,
+        InvalidPluginSetting = 28U,
+        ConflictingAuthority = 29U,
+        InvalidLogWrapperProgram = 30U
+    }
+}

--- a/Solnet.Metaplex/Core Program/MplCoreModels.cs
+++ b/Solnet.Metaplex/Core Program/MplCoreModels.cs
@@ -1,0 +1,289 @@
+﻿using Solnet.Wallet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+#pragma warning disable CS1591 
+namespace Solnet.Metaplex.Core.Models
+{
+    public class CreateV1Accounts
+    {
+        public PublicKey Asset { get; set; }
+
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Owner { get; set; }
+
+        public PublicKey UpdateAuthority = MplCoreProgram.programId;
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class CreateCollectionV1Accounts
+    {
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey UpdateAuthority { get; set; }
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+    }
+
+    public class AddPluginV1Accounts
+    {
+        public PublicKey Asset { get; set; }
+
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class AddCollectionPluginV1Accounts
+    {
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class RemovePluginV1Accounts
+    {
+        public PublicKey Asset { get; set; }
+
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class RemoveCollectionPluginV1Accounts
+    {
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class UpdatePluginV1Accounts
+    {
+        public PublicKey Asset { get; set; }
+
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class UpdateCollectionPluginV1Accounts
+    {
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class ApprovePluginAuthorityV1Accounts
+    {
+        public PublicKey Asset { get; set; }
+
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class ApproveCollectionPluginAuthorityV1Accounts
+    {
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class RevokePluginAuthorityV1Accounts
+    {
+        public PublicKey Asset { get; set; }
+
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class RevokeCollectionPluginAuthorityV1Accounts
+    {
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class BurnV1Accounts
+    {
+        public PublicKey Asset { get; set; }
+
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class BurnCollectionV1Accounts
+    {
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class TransferV1Accounts
+    {
+        public PublicKey Asset { get; set; }
+
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey NewOwner { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class UpdateV1Accounts
+    {
+        public PublicKey Asset { get; set; }
+
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class UpdateCollectionV1Accounts
+    {
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey NewUpdateAuthority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class CompressV1Accounts
+    {
+        public PublicKey Asset { get; set; }
+
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class DecompressV1Accounts
+    {
+        public PublicKey Asset { get; set; }
+
+        public PublicKey Collection = MplCoreProgram.programId;
+
+        public PublicKey Payer { get; set; }
+
+        public PublicKey Authority { get; set; }
+
+        public PublicKey SystemProgram = Programs.SystemProgram.ProgramIdKey;
+
+        public PublicKey LogWrapper = MplCoreProgram.programId;
+    }
+
+    public class CollectAccounts
+    {
+        public PublicKey Recipient1 { get; set; }
+
+        public PublicKey Recipient2 { get; set; }
+    }
+}

--- a/Solnet.Metaplex/Core Program/MplCoreProgram.cs
+++ b/Solnet.Metaplex/Core Program/MplCoreProgram.cs
@@ -1,0 +1,429 @@
+﻿using Solnet.KeyStore;
+using Solnet.Metaplex.Core.Models;
+using Solnet.Metaplex.Core.Types;
+using Solnet.Programs.Utilities;
+using Solnet.Rpc.Models;
+using Solnet.Wallet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+#pragma warning disable CS1591 
+namespace Solnet.Metaplex.Core
+{
+    public static class MplCoreProgram
+    {
+        public static PublicKey programId = new PublicKey("CoREENxT6tW1HoK8ypY1SxRMZTcVPm7R94rH4PZNhX7d");
+        public static TransactionInstruction CreateV1(CreateV1Accounts accounts, CreateV1Args createV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Asset, true), 
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Owner, false), 
+                AccountMeta.ReadOnly(accounts.UpdateAuthority, false), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(0, offset);
+            offset += 1;
+            offset += createV1Args.Serialize(_data, offset);
+            Console.WriteLine(_data.Length + " | " + offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+           
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction CreateCollectionV1(CreateCollectionV1Accounts accounts, CreateCollectionV1Args createCollectionV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Collection, true), 
+                AccountMeta.ReadOnly(accounts.UpdateAuthority, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(1, offset);
+            offset += 1;
+            offset += createCollectionV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction AddPluginV1(AddPluginV1Accounts accounts, AddPluginV1Args addPluginV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Asset, false), 
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(2, offset);
+            offset += 8;
+            offset += addPluginV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction AddCollectionPluginV1(AddCollectionPluginV1Accounts accounts, AddCollectionPluginV1Args addCollectionPluginV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(3, offset);
+            offset += 1;
+            offset += addCollectionPluginV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction RemovePluginV1(RemovePluginV1Accounts accounts, RemovePluginV1Args removePluginV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Asset, false), 
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true),
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(4, offset);
+            offset += 1;
+            offset += removePluginV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction RemoveCollectionPluginV1(RemoveCollectionPluginV1Accounts accounts, RemoveCollectionPluginV1Args removeCollectionPluginV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(5, offset);
+            offset += 1;
+            offset += removeCollectionPluginV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction UpdatePluginV1(UpdatePluginV1Accounts accounts, UpdatePluginV1Args updatePluginV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Asset, false), 
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(6, offset);
+            offset += 1;
+            offset += updatePluginV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction UpdateCollectionPluginV1(UpdateCollectionPluginV1Accounts accounts, UpdateCollectionPluginV1Args updateCollectionPluginV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(7, offset);
+            offset += 1;
+            offset += updateCollectionPluginV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction ApprovePluginAuthorityV1(ApprovePluginAuthorityV1Accounts accounts, ApprovePluginAuthorityV1Args approvePluginAuthorityV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Asset, false), 
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(8, offset);
+            offset += 1;
+            offset += approvePluginAuthorityV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction ApproveCollectionPluginAuthorityV1(ApproveCollectionPluginAuthorityV1Accounts accounts, ApproveCollectionPluginAuthorityV1Args approveCollectionPluginAuthorityV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(9, offset);
+            offset += 1;
+            offset += approveCollectionPluginAuthorityV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction RevokePluginAuthorityV1(RevokePluginAuthorityV1Accounts accounts, RevokePluginAuthorityV1Args revokePluginAuthorityV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Asset, false), 
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(10, offset);
+            offset += 1;
+            offset += revokePluginAuthorityV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction RevokeCollectionPluginAuthorityV1(RevokeCollectionPluginAuthorityV1Accounts accounts, RevokeCollectionPluginAuthorityV1Args revokeCollectionPluginAuthorityV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(11, offset);
+            offset += 1;
+            offset += revokeCollectionPluginAuthorityV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction BurnV1(BurnV1Accounts accounts, BurnV1Args burnV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Asset, false), 
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(12, offset);
+            offset += 1;
+            offset += burnV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction BurnCollectionV1(BurnCollectionV1Accounts accounts, BurnCollectionV1Args burnCollectionV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(13, offset);
+            offset += 1;
+            offset += burnCollectionV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction TransferV1(TransferV1Accounts accounts, TransferV1Args transferV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Asset, false), 
+                AccountMeta.ReadOnly(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.NewOwner, false), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(14, offset);
+            offset += 1;
+            offset += transferV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction UpdateV1(UpdateV1Accounts accounts, UpdateV1Args updateV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Asset, false), 
+                AccountMeta.ReadOnly(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(15, offset);
+            offset += 1;
+            offset += updateV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction UpdateCollectionV1(UpdateCollectionV1Accounts accounts, UpdateCollectionV1Args updateCollectionV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.NewUpdateAuthority, false), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(16, offset);
+            offset += 1;
+            offset += updateCollectionV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction CompressV1(CompressV1Accounts accounts, CompressV1Args compressV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Asset, false), 
+                AccountMeta.ReadOnly(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false), 
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(17, offset);
+            offset += 1;
+            offset += compressV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction DecompressV1(DecompressV1Accounts accounts, DecompressV1Args decompressV1Args)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Asset, false), 
+                AccountMeta.ReadOnly(accounts.Collection, false), 
+                AccountMeta.Writable(accounts.Payer, true), 
+                AccountMeta.ReadOnly(accounts.Authority, true), 
+                AccountMeta.ReadOnly(accounts.SystemProgram, false),
+                AccountMeta.ReadOnly(accounts.LogWrapper, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(18, offset);
+            offset += 1;
+            offset += decompressV1Args.Serialize(_data, offset);
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+
+        public static TransactionInstruction Collect(CollectAccounts accounts)
+        {
+            List<AccountMeta> keys = new()
+            {
+                AccountMeta.Writable(accounts.Recipient1, false), 
+                AccountMeta.Writable(accounts.Recipient2, false)
+            };
+            byte[] _data = new byte[1200];
+            int offset = 0;
+            _data.WriteU8(19, offset);
+            offset += 1;
+            byte[] resultData = new byte[offset];
+            Array.Copy(_data, resultData, offset);
+            return new TransactionInstruction { Keys = keys, ProgramId = programId.KeyBytes, Data = resultData };
+        }
+    }
+}

--- a/Solnet.Metaplex/Core Program/MplCoreProgram.cs
+++ b/Solnet.Metaplex/Core Program/MplCoreProgram.cs
@@ -1,14 +1,10 @@
-﻿using Solnet.KeyStore;
-using Solnet.Metaplex.Core.Models;
+﻿using Solnet.Metaplex.Core.Models;
 using Solnet.Metaplex.Core.Types;
 using Solnet.Programs.Utilities;
 using Solnet.Rpc.Models;
 using Solnet.Wallet;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 #pragma warning disable CS1591 
 namespace Solnet.Metaplex.Core
 {

--- a/Solnet.Metaplex/Core Program/MplCoreTypes.cs
+++ b/Solnet.Metaplex/Core Program/MplCoreTypes.cs
@@ -1,0 +1,1693 @@
+﻿using Solnet.Programs.Utilities;
+using Solnet.Wallet;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+namespace Solnet.Metaplex.Core.Types
+{
+    public partial class PluginAuthorityPair
+    {
+        public Plugin Plugin { get; set; }
+
+        public Authority Authority { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            offset += Plugin.Serialize(_data, offset);
+            if (Authority != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                offset += Authority.Serialize(_data, offset);
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out PluginAuthorityPair result)
+        {
+            int offset = initialOffset;
+            result = new PluginAuthorityPair();
+            offset += Plugin.Deserialize(_data, offset, out var resultPlugin);
+            result.Plugin = resultPlugin;
+            if (_data.GetBool(offset++))
+            {
+                offset += Authority.Deserialize(_data, offset, out var resultAuthority);
+                result.Authority = resultAuthority;
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class Attribute
+    {
+        public string Key { get; set; }
+
+        public string Value { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            offset += _data.WriteBorshString(Key, offset);
+            offset += _data.WriteBorshString(Value, offset);
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out Attribute result)
+        {
+            int offset = initialOffset;
+            result = new Attribute();
+            offset += _data.GetBorshString(offset, out var resultKey);
+            result.Key = resultKey;
+            offset += _data.GetBorshString(offset, out var resultValue);
+            result.Value = resultValue;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class Attributes
+    {
+        public Attribute[] AttributeList { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteS32(AttributeList.Length, offset);
+            offset += 4;
+            foreach (var attributeListElement in AttributeList)
+            {
+                offset += attributeListElement.Serialize(_data, offset);
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out Attributes result)
+        {
+            int offset = initialOffset;
+            result = new Attributes();
+            int resultAttributeListLength = (int)_data.GetU32(offset);
+            offset += 4;
+            result.AttributeList = new Attribute[resultAttributeListLength];
+            for (uint resultAttributeListIdx = 0; resultAttributeListIdx < resultAttributeListLength; resultAttributeListIdx++)
+            {
+                offset += Attribute.Deserialize(_data, offset, out var resultAttributeListresultAttributeListIdx);
+                result.AttributeList[resultAttributeListIdx] = resultAttributeListresultAttributeListIdx;
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class BurnDelegate
+    {
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out BurnDelegate result)
+        {
+            int offset = initialOffset;
+            result = new BurnDelegate();
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class Edition
+    {
+        public uint Number { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU32(Number, offset);
+            offset += 4;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out Edition result)
+        {
+            int offset = initialOffset;
+            result = new Edition();
+            result.Number = _data.GetU32(offset);
+            offset += 4;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class FreezeDelegate
+    {
+        public bool Frozen { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteBool(Frozen, offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out FreezeDelegate result)
+        {
+            int offset = initialOffset;
+            result = new FreezeDelegate();
+            result.Frozen = _data.GetBool(offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class MasterEdition
+    {
+        public uint? MaxSupply { get; set; }
+
+        public string Name { get; set; }
+
+        public string Uri { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            if (MaxSupply != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                _data.WriteU32(MaxSupply.Value, offset);
+                offset += 4;
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            if (Name != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                offset += _data.WriteBorshString(Name, offset);
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            if (Uri != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                offset += _data.WriteBorshString(Uri, offset);
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out MasterEdition result)
+        {
+            int offset = initialOffset;
+            result = new MasterEdition();
+            if (_data.GetBool(offset++))
+            {
+                result.MaxSupply = _data.GetU32(offset);
+                offset += 4;
+            }
+
+            if (_data.GetBool(offset++))
+            {
+                offset += _data.GetBorshString(offset, out var resultName);
+                result.Name = resultName;
+            }
+
+            if (_data.GetBool(offset++))
+            {
+                offset += _data.GetBorshString(offset, out var resultUri);
+                result.Uri = resultUri;
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class PermanentBurnDelegate
+    {
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out PermanentBurnDelegate result)
+        {
+            int offset = initialOffset;
+            result = new PermanentBurnDelegate();
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class PermanentFreezeDelegate
+    {
+        public bool Frozen { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteBool(Frozen, offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out PermanentFreezeDelegate result)
+        {
+            int offset = initialOffset;
+            result = new PermanentFreezeDelegate();
+            result.Frozen = _data.GetBool(offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class PermanentTransferDelegate
+    {
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out PermanentTransferDelegate result)
+        {
+            int offset = initialOffset;
+            result = new PermanentTransferDelegate();
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class RegistryRecord
+    {
+        public PluginType PluginType { get; set; }
+
+        public Authority Authority { get; set; }
+
+        public ulong Offset { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU8((byte)PluginType, offset);
+            offset += 1;
+            offset += Authority.Serialize(_data, offset);
+            _data.WriteU64(Offset, offset);
+            offset += 8;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out RegistryRecord result)
+        {
+            int offset = initialOffset;
+            result = new RegistryRecord();
+            result.PluginType = (PluginType)_data.GetU8(offset);
+            offset += 1;
+            offset += Authority.Deserialize(_data, offset, out var resultAuthority);
+            result.Authority = resultAuthority;
+            result.Offset = _data.GetU64(offset);
+            offset += 8;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class ExternalPluginRecord
+    {
+        public Authority Authority { get; set; }
+
+        public ulong Offset { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            offset += Authority.Serialize(_data, offset);
+            _data.WriteU64(Offset, offset);
+            offset += 8;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out ExternalPluginRecord result)
+        {
+            int offset = initialOffset;
+            result = new ExternalPluginRecord();
+            offset += Authority.Deserialize(_data, offset, out var resultAuthority);
+            result.Authority = resultAuthority;
+            result.Offset = _data.GetU64(offset);
+            offset += 8;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class Creator
+    {
+        public PublicKey Address { get; set; }
+
+        public byte Percentage { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WritePubKey(Address, offset);
+            offset += 32;
+            _data.WriteU8(Percentage, offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out Creator result)
+        {
+            int offset = initialOffset;
+            result = new Creator();
+            result.Address = _data.GetPubKey(offset);
+            offset += 32;
+            result.Percentage = _data.GetU8(offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class Royalties
+    {
+        public ushort BasisPoints { get; set; }
+
+        public Creator[] Creators { get; set; }
+
+        public RuleSet RuleSet { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU16(BasisPoints, offset);
+            offset += 2;
+            _data.WriteS32(Creators.Length, offset);
+            offset += 4;
+            foreach (var creatorsElement in Creators)
+            {
+                offset += creatorsElement.Serialize(_data, offset);
+            }
+
+            offset += RuleSet.Serialize(_data, offset);
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out Royalties result)
+        {
+            int offset = initialOffset;
+            result = new Royalties();
+            result.BasisPoints = _data.GetU16(offset);
+            offset += 2;
+            int resultCreatorsLength = (int)_data.GetU32(offset);
+            offset += 4;
+            result.Creators = new Creator[resultCreatorsLength];
+            for (uint resultCreatorsIdx = 0; resultCreatorsIdx < resultCreatorsLength; resultCreatorsIdx++)
+            {
+                offset += Creator.Deserialize(_data, offset, out var resultCreatorsresultCreatorsIdx);
+                result.Creators[resultCreatorsIdx] = resultCreatorsresultCreatorsIdx;
+            }
+
+            offset += RuleSet.Deserialize(_data, offset, out var resultRuleSet);
+            result.RuleSet = resultRuleSet;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class TransferDelegate
+    {
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out TransferDelegate result)
+        {
+            int offset = initialOffset;
+            result = new TransferDelegate();
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class UpdateDelegate
+    {
+        public PublicKey[] AdditionalDelegates { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteS32(AdditionalDelegates.Length, offset);
+            offset += 4;
+            foreach (var additionalDelegatesElement in AdditionalDelegates)
+            {
+                _data.WritePubKey(additionalDelegatesElement, offset);
+                offset += 32;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out UpdateDelegate result)
+        {
+            int offset = initialOffset;
+            result = new UpdateDelegate();
+            int resultAdditionalDelegatesLength = (int)_data.GetU32(offset);
+            offset += 4;
+            result.AdditionalDelegates = new PublicKey[resultAdditionalDelegatesLength];
+            for (uint resultAdditionalDelegatesIdx = 0; resultAdditionalDelegatesIdx < resultAdditionalDelegatesLength; resultAdditionalDelegatesIdx++)
+            {
+                result.AdditionalDelegates[resultAdditionalDelegatesIdx] = _data.GetPubKey(offset);
+                offset += 32;
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class AddPluginV1Args
+    {
+        public Plugin Plugin { get; set; }
+
+        public Authority InitAuthority { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            offset += Plugin.Serialize(_data, offset);
+            if (InitAuthority != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                offset += InitAuthority.Serialize(_data, offset);
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out AddPluginV1Args result)
+        {
+            int offset = initialOffset;
+            result = new AddPluginV1Args();
+            offset += Plugin.Deserialize(_data, offset, out var resultPlugin);
+            result.Plugin = resultPlugin;
+            if (_data.GetBool(offset++))
+            {
+                offset += Authority.Deserialize(_data, offset, out var resultInitAuthority);
+                result.InitAuthority = resultInitAuthority;
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class AddCollectionPluginV1Args
+    {
+        public Plugin Plugin { get; set; }
+
+        public Authority InitAuthority { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            offset += Plugin.Serialize(_data, offset);
+            if (InitAuthority != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                offset += InitAuthority.Serialize(_data, offset);
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out AddCollectionPluginV1Args result)
+        {
+            int offset = initialOffset;
+            result = new AddCollectionPluginV1Args();
+            offset += Plugin.Deserialize(_data, offset, out var resultPlugin);
+            result.Plugin = resultPlugin;
+            if (_data.GetBool(offset++))
+            {
+                offset += Authority.Deserialize(_data, offset, out var resultInitAuthority);
+                result.InitAuthority = resultInitAuthority;
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class ApprovePluginAuthorityV1Args
+    {
+        public PluginType PluginType { get; set; }
+
+        public Authority NewAuthority { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU8((byte)PluginType, offset);
+            offset += 1;
+            offset += NewAuthority.Serialize(_data, offset);
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out ApprovePluginAuthorityV1Args result)
+        {
+            int offset = initialOffset;
+            result = new ApprovePluginAuthorityV1Args();
+            result.PluginType = (PluginType)_data.GetU8(offset);
+            offset += 1;
+            offset += Authority.Deserialize(_data, offset, out var resultNewAuthority);
+            result.NewAuthority = resultNewAuthority;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class ApproveCollectionPluginAuthorityV1Args
+    {
+        public PluginType PluginType { get; set; }
+
+        public Authority NewAuthority { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU8((byte)PluginType, offset);
+            offset += 1;
+            offset += NewAuthority.Serialize(_data, offset);
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out ApproveCollectionPluginAuthorityV1Args result)
+        {
+            int offset = initialOffset;
+            result = new ApproveCollectionPluginAuthorityV1Args();
+            result.PluginType = (PluginType)_data.GetU8(offset);
+            offset += 1;
+            offset += Authority.Deserialize(_data, offset, out var resultNewAuthority);
+            result.NewAuthority = resultNewAuthority;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class BurnV1Args
+    {
+        public CompressionProof CompressionProof { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            if (CompressionProof != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                offset += CompressionProof.Serialize(_data, offset);
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out BurnV1Args result)
+        {
+            int offset = initialOffset;
+            result = new BurnV1Args();
+            if (_data.GetBool(offset++))
+            {
+                offset += CompressionProof.Deserialize(_data, offset, out var resultCompressionProof);
+                result.CompressionProof = resultCompressionProof;
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class BurnCollectionV1Args
+    {
+        public CompressionProof CompressionProof { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            if (CompressionProof != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                offset += CompressionProof.Serialize(_data, offset);
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out BurnCollectionV1Args result)
+        {
+            int offset = initialOffset;
+            result = new BurnCollectionV1Args();
+            if (_data.GetBool(offset++))
+            {
+                offset += CompressionProof.Deserialize(_data, offset, out var resultCompressionProof);
+                result.CompressionProof = resultCompressionProof;
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class CompressV1Args
+    {
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out CompressV1Args result)
+        {
+            int offset = initialOffset;
+            result = new CompressV1Args();
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class CreateV1Args
+    {
+        public DataState DataState { get; set; }
+
+        public string Name { get; set; }
+
+        public string Uri { get; set; }
+
+        public PluginAuthorityPair[] Plugins { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            byte[] encodedName = Encoding.UTF8.GetBytes(Name);
+            byte[] encodedUri = Encoding.UTF8.GetBytes(Uri);
+            int offset = initialOffset;
+            _data.WriteU8((byte)DataState, offset);
+
+            offset += 1;
+            offset += _data.WriteBorshString(Name, offset);
+            offset += _data.WriteBorshString(Uri, offset);
+            if (Plugins != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                _data.WriteS32(Plugins.Length, offset);
+                offset += 4;
+                foreach (var pluginsElement in Plugins)
+                {
+                    offset += pluginsElement.Serialize(_data, offset);
+                }
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out CreateV1Args result)
+        {
+            int offset = initialOffset;
+            result = new CreateV1Args();
+            result.DataState = (DataState)_data.GetU8(offset);
+            offset += 1;
+            int nameLength = 0;
+            nameLength = _data.GetU8(offset);
+            offset += 1;
+            result.Name = Encoding.UTF8.GetString(_data.Slice(offset, offset+ nameLength));
+
+
+            offset += nameLength;
+
+            if (_data.GetBool(offset++))
+            {
+                int resultPluginsLength = (int)_data.GetU32(offset);
+                offset += 4;
+                result.Plugins = new PluginAuthorityPair[resultPluginsLength];
+                for (uint resultPluginsIdx = 0; resultPluginsIdx < resultPluginsLength; resultPluginsIdx++)
+                {
+                    offset += PluginAuthorityPair.Deserialize(_data, offset, out var resultPluginsresultPluginsIdx);
+                    result.Plugins[resultPluginsIdx] = resultPluginsresultPluginsIdx;
+                }
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class CreateCollectionV1Args
+    {
+        public string Name { get; set; }
+
+        public string Uri { get; set; }
+
+        public PluginAuthorityPair[] Plugins { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            offset += _data.WriteBorshString(Name, offset);
+            offset += _data.WriteBorshString(Uri, offset);
+            if (Plugins != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                _data.WriteS32(Plugins.Length, offset);
+                offset += 4;
+                foreach (var pluginsElement in Plugins)
+                {
+                    offset += pluginsElement.Serialize(_data, offset);
+                }
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out CreateCollectionV1Args result)
+        {
+            int offset = initialOffset;
+            result = new CreateCollectionV1Args();
+            offset += _data.GetBorshString(offset, out var resultName);
+            result.Name = resultName;
+            offset += _data.GetBorshString(offset, out var resultUri);
+            result.Uri = resultUri;
+            if (_data.GetBool(offset++))
+            {
+                int resultPluginsLength = (int)_data.GetU32(offset);
+                offset += 4;
+                result.Plugins = new PluginAuthorityPair[resultPluginsLength];
+                for (uint resultPluginsIdx = 0; resultPluginsIdx < resultPluginsLength; resultPluginsIdx++)
+                {
+                    offset += PluginAuthorityPair.Deserialize(_data, offset, out var resultPluginsresultPluginsIdx);
+                    result.Plugins[resultPluginsIdx] = resultPluginsresultPluginsIdx;
+                }
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class DecompressV1Args
+    {
+        public CompressionProof CompressionProof { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            offset += CompressionProof.Serialize(_data, offset);
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out DecompressV1Args result)
+        {
+            int offset = initialOffset;
+            result = new DecompressV1Args();
+            offset += CompressionProof.Deserialize(_data, offset, out var resultCompressionProof);
+            result.CompressionProof = resultCompressionProof;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class RemovePluginV1Args
+    {
+        public PluginType PluginType { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU8((byte)PluginType, offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out RemovePluginV1Args result)
+        {
+            int offset = initialOffset;
+            result = new RemovePluginV1Args();
+            result.PluginType = (PluginType)_data.GetU8(offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class RemoveCollectionPluginV1Args
+    {
+        public PluginType PluginType { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU8((byte)PluginType, offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out RemoveCollectionPluginV1Args result)
+        {
+            int offset = initialOffset;
+            result = new RemoveCollectionPluginV1Args();
+            result.PluginType = (PluginType)_data.GetU8(offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class RevokePluginAuthorityV1Args
+    {
+        public PluginType PluginType { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU8((byte)PluginType, offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out RevokePluginAuthorityV1Args result)
+        {
+            int offset = initialOffset;
+            result = new RevokePluginAuthorityV1Args();
+            result.PluginType = (PluginType)_data.GetU8(offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class RevokeCollectionPluginAuthorityV1Args
+    {
+        public PluginType PluginType { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU8((byte)PluginType, offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out RevokeCollectionPluginAuthorityV1Args result)
+        {
+            int offset = initialOffset;
+            result = new RevokeCollectionPluginAuthorityV1Args();
+            result.PluginType = (PluginType)_data.GetU8(offset);
+            offset += 1;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class TransferV1Args
+    {
+        public CompressionProof CompressionProof { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            if (CompressionProof != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                offset += CompressionProof.Serialize(_data, offset);
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out TransferV1Args result)
+        {
+            int offset = initialOffset;
+            result = new TransferV1Args();
+            if (_data.GetBool(offset++))
+            {
+                offset += CompressionProof.Deserialize(_data, offset, out var resultCompressionProof);
+                result.CompressionProof = resultCompressionProof;
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class UpdateV1Args
+    {
+        public string NewName { get; set; }
+
+        public string NewUri { get; set; }
+
+        public UpdateAuthority NewUpdateAuthority { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            if (NewName != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                offset += _data.WriteBorshString(NewName, offset);
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            if (NewUri != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                offset += _data.WriteBorshString(NewUri, offset);
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            if (NewUpdateAuthority != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                offset += NewUpdateAuthority.Serialize(_data, offset);
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out UpdateV1Args result)
+        {
+            int offset = initialOffset;
+            result = new UpdateV1Args();
+            if (_data.GetBool(offset++))
+            {
+                offset += _data.GetBorshString(offset, out var resultNewName);
+                result.NewName = resultNewName;
+            }
+
+            if (_data.GetBool(offset++))
+            {
+                offset += _data.GetBorshString(offset, out var resultNewUri);
+                result.NewUri = resultNewUri;
+            }
+
+            if (_data.GetBool(offset++))
+            {
+                offset += UpdateAuthority.Deserialize(_data, offset, out var resultNewUpdateAuthority);
+                result.NewUpdateAuthority = resultNewUpdateAuthority;
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class UpdateCollectionV1Args
+    {
+        public string NewName { get; set; }
+
+        public string NewUri { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            if (NewName != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                offset += _data.WriteBorshString(NewName, offset);
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            if (NewUri != null)
+            {
+                _data.WriteU8(1, offset);
+                offset += 1;
+                offset += _data.WriteBorshString(NewUri, offset);
+            }
+            else
+            {
+                _data.WriteU8(0, offset);
+                offset += 1;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out UpdateCollectionV1Args result)
+        {
+            int offset = initialOffset;
+            result = new UpdateCollectionV1Args();
+            if (_data.GetBool(offset++))
+            {
+                offset += _data.GetBorshString(offset, out var resultNewName);
+                result.NewName = resultNewName;
+            }
+
+            if (_data.GetBool(offset++))
+            {
+                offset += _data.GetBorshString(offset, out var resultNewUri);
+                result.NewUri = resultNewUri;
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class UpdatePluginV1Args
+    {
+        public Plugin Plugin { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            offset += Plugin.Serialize(_data, offset);
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out UpdatePluginV1Args result)
+        {
+            int offset = initialOffset;
+            result = new UpdatePluginV1Args();
+            offset += Plugin.Deserialize(_data, offset, out var resultPlugin);
+            result.Plugin = resultPlugin;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class UpdateCollectionPluginV1Args
+    {
+        public Plugin Plugin { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            offset += Plugin.Serialize(_data, offset);
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out UpdateCollectionPluginV1Args result)
+        {
+            int offset = initialOffset;
+            result = new UpdateCollectionPluginV1Args();
+            offset += Plugin.Deserialize(_data, offset, out var resultPlugin);
+            result.Plugin = resultPlugin;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class CompressionProof
+    {
+        public PublicKey Owner { get; set; }
+
+        public UpdateAuthority UpdateAuthority { get; set; }
+
+        public string Name { get; set; }
+
+        public string Uri { get; set; }
+
+        public ulong Seq { get; set; }
+
+        public HashablePluginSchema[] Plugins { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WritePubKey(Owner, offset);
+            offset += 32;
+            offset += UpdateAuthority.Serialize(_data, offset);
+            offset += _data.WriteBorshString(Name, offset);
+            offset += _data.WriteBorshString(Uri, offset);
+            _data.WriteU64(Seq, offset);
+            offset += 8;
+            _data.WriteS32(Plugins.Length, offset);
+            offset += 4;
+            foreach (var pluginsElement in Plugins)
+            {
+                offset += pluginsElement.Serialize(_data, offset);
+            }
+
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out CompressionProof result)
+        {
+            int offset = initialOffset;
+            result = new CompressionProof();
+            result.Owner = _data.GetPubKey(offset);
+            offset += 32;
+            offset += UpdateAuthority.Deserialize(_data, offset, out var resultUpdateAuthority);
+            result.UpdateAuthority = resultUpdateAuthority;
+            offset += _data.GetBorshString(offset, out var resultName);
+            result.Name = resultName;
+            offset += _data.GetBorshString(offset, out var resultUri);
+            result.Uri = resultUri;
+            result.Seq = _data.GetU64(offset);
+            offset += 8;
+            int resultPluginsLength = (int)_data.GetU32(offset);
+            offset += 4;
+            result.Plugins = new HashablePluginSchema[resultPluginsLength];
+            for (uint resultPluginsIdx = 0; resultPluginsIdx < resultPluginsLength; resultPluginsIdx++)
+            {
+                offset += HashablePluginSchema.Deserialize(_data, offset, out var resultPluginsresultPluginsIdx);
+                result.Plugins[resultPluginsIdx] = resultPluginsresultPluginsIdx;
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class HashablePluginSchema
+    {
+        public ulong Index { get; set; }
+
+        public Authority Authority { get; set; }
+
+        public Plugin Plugin { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU64(Index, offset);
+            offset += 8;
+            offset += Authority.Serialize(_data, offset);
+            offset += Plugin.Serialize(_data, offset);
+            return offset - initialOffset;
+        }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out HashablePluginSchema result)
+        {
+            int offset = initialOffset;
+            result = new HashablePluginSchema();
+            result.Index = _data.GetU64(offset);
+            offset += 8;
+            offset += Authority.Deserialize(_data, offset, out var resultAuthority);
+            result.Authority = resultAuthority;
+            offset += Plugin.Deserialize(_data, offset, out var resultPlugin);
+            result.Plugin = resultPlugin;
+            return offset - initialOffset;
+        }
+    }
+
+    public enum PluginType : byte
+    {
+        Royalties,
+        FreezeDelegate,
+        BurnDelegate,
+        TransferDelegate,
+        UpdateDelegate,
+        PermanentFreezeDelegate,
+        Attributes,
+        PermanentTransferDelegate,
+        PermanentBurnDelegate,
+        Edition,
+        MasterEdition
+    }
+
+    public partial class Plugin
+    {
+        public Tuple<Royalties> RoyaltiesValue { get; set; }
+
+        public Tuple<FreezeDelegate> FreezeDelegateValue { get; set; }
+
+        public Tuple<BurnDelegate> BurnDelegateValue { get; set; }
+
+        public Tuple<TransferDelegate> TransferDelegateValue { get; set; }
+
+        public Tuple<UpdateDelegate> UpdateDelegateValue { get; set; }
+
+        public Tuple<PermanentFreezeDelegate> PermanentFreezeDelegateValue { get; set; }
+
+        public Tuple<Attributes> AttributesValue { get; set; }
+
+        public Tuple<PermanentTransferDelegate> PermanentTransferDelegateValue { get; set; }
+
+        public Tuple<PermanentBurnDelegate> PermanentBurnDelegateValue { get; set; }
+
+        public Tuple<Edition> EditionValue { get; set; }
+
+        public Tuple<MasterEdition> MasterEditionValue { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU8((byte)Type, offset);
+            offset += 1;
+            switch (Type)
+            {
+                case PluginType.Royalties:
+                    offset += RoyaltiesValue.Item1.Serialize(_data, offset);
+                    break;
+                case PluginType.FreezeDelegate:
+                    offset += FreezeDelegateValue.Item1.Serialize(_data, offset);
+                    break;
+                case PluginType.BurnDelegate:
+                    offset += BurnDelegateValue.Item1.Serialize(_data, offset);
+                    break;
+                case PluginType.TransferDelegate:
+                    offset += TransferDelegateValue.Item1.Serialize(_data, offset);
+                    break;
+                case PluginType.UpdateDelegate:
+                    offset += UpdateDelegateValue.Item1.Serialize(_data, offset);
+                    break;
+                case PluginType.PermanentFreezeDelegate:
+                    offset += PermanentFreezeDelegateValue.Item1.Serialize(_data, offset);
+                    break;
+                case PluginType.Attributes:
+                    offset += AttributesValue.Item1.Serialize(_data, offset);
+                    break;
+                case PluginType.PermanentTransferDelegate:
+                    offset += PermanentTransferDelegateValue.Item1.Serialize(_data, offset);
+                    break;
+                case PluginType.PermanentBurnDelegate:
+                    offset += PermanentBurnDelegateValue.Item1.Serialize(_data, offset);
+                    break;
+                case PluginType.Edition:
+                    offset += EditionValue.Item1.Serialize(_data, offset);
+                    break;
+                case PluginType.MasterEdition:
+                    offset += MasterEditionValue.Item1.Serialize(_data, offset);
+                    break;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public PluginType Type { get; set; }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out Plugin result)
+        {
+            int offset = initialOffset;
+            result = new Plugin();
+            result.Type = (PluginType)_data.GetU8(offset);
+            offset += 1;
+            switch (result.Type)
+            {
+                case PluginType.Royalties:
+                    {
+                        Royalties RoyaltiesItem1;
+                        offset += Royalties.Deserialize(_data, offset, out var royaltiesItem1);
+                        RoyaltiesItem1 = royaltiesItem1;
+                        result.RoyaltiesValue = Tuple.Create(RoyaltiesItem1);
+                        break;
+                    }
+
+                case PluginType.FreezeDelegate:
+                    {
+                        FreezeDelegate FreezeDelegateItem1;
+                        offset += FreezeDelegate.Deserialize(_data, offset, out var freezeDelegateItem1);
+                        FreezeDelegateItem1 = freezeDelegateItem1;
+                        result.FreezeDelegateValue = Tuple.Create(FreezeDelegateItem1);
+                        break;
+                    }
+
+                case PluginType.BurnDelegate:
+                    {
+                        BurnDelegate BurnDelegateItem1;
+                        offset += BurnDelegate.Deserialize(_data, offset, out var burnDelegateItem1);
+                        BurnDelegateItem1 = burnDelegateItem1;
+                        result.BurnDelegateValue = Tuple.Create(BurnDelegateItem1);
+                        break;
+                    }
+
+                case PluginType.TransferDelegate:
+                    {
+                        TransferDelegate TransferDelegateItem1;
+                        offset += TransferDelegate.Deserialize(_data, offset, out var transferDelegateItem1);
+                        TransferDelegateItem1 = transferDelegateItem1;
+                        result.TransferDelegateValue = Tuple.Create(TransferDelegateItem1);
+                        break;
+                    }
+
+                case PluginType.UpdateDelegate:
+                    {
+                        UpdateDelegate UpdateDelegateItem1;
+                        offset += UpdateDelegate.Deserialize(_data, offset, out var updateDelegateItem1);
+                        UpdateDelegateItem1 = updateDelegateItem1;
+                        result.UpdateDelegateValue = Tuple.Create(UpdateDelegateItem1);
+                        break;
+                    }
+
+                case PluginType.PermanentFreezeDelegate:
+                    {
+                        PermanentFreezeDelegate PermanentFreezeDelegateItem1;
+                        offset += PermanentFreezeDelegate.Deserialize(_data, offset, out var permanentFreezeDelegateItem1);
+                        PermanentFreezeDelegateItem1 = permanentFreezeDelegateItem1;
+                        result.PermanentFreezeDelegateValue = Tuple.Create(PermanentFreezeDelegateItem1);
+                        break;
+                    }
+
+                case PluginType.Attributes:
+                    {
+                        Attributes AttributesItem1;
+                        offset += Attributes.Deserialize(_data, offset, out var attributesItem1);
+                        AttributesItem1 = attributesItem1;
+                        result.AttributesValue = Tuple.Create(AttributesItem1);
+                        break;
+                    }
+
+                case PluginType.PermanentTransferDelegate:
+                    {
+                        PermanentTransferDelegate PermanentTransferDelegateItem1;
+                        offset += PermanentTransferDelegate.Deserialize(_data, offset, out var permanentTransferDelegateItem1);
+                        PermanentTransferDelegateItem1 = permanentTransferDelegateItem1;
+                        result.PermanentTransferDelegateValue = Tuple.Create(PermanentTransferDelegateItem1);
+                        break;
+                    }
+
+                case PluginType.PermanentBurnDelegate:
+                    {
+                        PermanentBurnDelegate PermanentBurnDelegateItem1;
+                        offset += PermanentBurnDelegate.Deserialize(_data, offset, out var permanentBurnDelegateItem1);
+                        PermanentBurnDelegateItem1 = permanentBurnDelegateItem1;
+                        result.PermanentBurnDelegateValue = Tuple.Create(PermanentBurnDelegateItem1);
+                        break;
+                    }
+
+                case PluginType.Edition:
+                    {
+                        Edition EditionItem1;
+                        offset += Edition.Deserialize(_data, offset, out var editionItem1);
+                        EditionItem1 = editionItem1;
+                        result.EditionValue = Tuple.Create(EditionItem1);
+                        break;
+                    }
+
+                case PluginType.MasterEdition:
+                    {
+                        MasterEdition MasterEditionItem1;
+                        offset += MasterEdition.Deserialize(_data, offset, out var masterEditionItem1);
+                        MasterEditionItem1 = masterEditionItem1;
+                        result.MasterEditionValue = Tuple.Create(MasterEditionItem1);
+                        break;
+                    }
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public enum RuleSetType : byte
+    {
+        None,
+        ProgramAllowList,
+        ProgramDenyList
+    }
+
+    public partial class RuleSet
+    {
+        public Tuple<PublicKey[]> ProgramAllowListValue { get; set; }
+
+        public Tuple<PublicKey[]> ProgramDenyListValue { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU8((byte)Type, offset);
+            offset += 1;
+            switch (Type)
+            {
+                case RuleSetType.ProgramAllowList:
+                    _data.WriteS32(ProgramAllowListValue.Item1.Length, offset);
+                    offset += 4;
+                    foreach (var programAllowListValue in ProgramAllowListValue.Item1)
+                        {
+                        _data.WritePubKey(programAllowListValue, offset);
+                        offset += 32;
+                    }
+
+                    break;
+                case RuleSetType.ProgramDenyList:
+                    _data.WriteS32(ProgramDenyListValue.Item1.Length, offset);
+                    offset += 4;
+                    foreach (var programDenyListValue in ProgramDenyListValue.Item1)
+                        {
+                        _data.WritePubKey(programDenyListValue, offset);
+                        offset += 32;
+                    }
+
+                    break;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public RuleSetType Type { get; set; }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out RuleSet result)
+        {
+            int offset = initialOffset;
+            result = new RuleSet();
+            result.Type = (RuleSetType)_data.GetU8(offset);
+            offset += 1;
+            switch (result.Type)
+            {
+                case RuleSetType.ProgramAllowList:
+                    {
+                        PublicKey[] ProgramAllowListItem1;
+                        int programAllowListItem1Length = (int)_data.GetU32(offset);
+                        offset += 4;
+                        ProgramAllowListItem1 = new PublicKey[programAllowListItem1Length];
+                        for (uint programAllowListItem1Idx = 0; programAllowListItem1Idx < programAllowListItem1Length; programAllowListItem1Idx++)
+                        {
+                            ProgramAllowListItem1[programAllowListItem1Idx] = _data.GetPubKey(offset);
+                            offset += 32;
+                        }
+
+                        result.ProgramAllowListValue = Tuple.Create(ProgramAllowListItem1);
+                        break;
+                    }
+
+                case RuleSetType.ProgramDenyList:
+                    {
+                        PublicKey[] ProgramDenyListItem1;
+                        int programDenyListItem1Length = (int)_data.GetU32(offset);
+                        offset += 4;
+                        ProgramDenyListItem1 = new PublicKey[programDenyListItem1Length];
+                        for (uint programDenyListItem1Idx = 0; programDenyListItem1Idx < programDenyListItem1Length; programDenyListItem1Idx++)
+                        {
+                            ProgramDenyListItem1[programDenyListItem1Idx] = _data.GetPubKey(offset);
+                            offset += 32;
+                        }
+
+                        result.ProgramDenyListValue = Tuple.Create(ProgramDenyListItem1);
+                        break;
+                    }
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public enum DataState : byte
+    {
+        AccountState,
+        LedgerState
+    }
+
+    public enum AuthorityType : byte
+    {
+        None,
+        Owner,
+        UpdateAuthority,
+        Address
+    }
+
+    public partial class AddressType
+    {
+        public PublicKey Address { get; set; }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out AddressType result)
+        {
+            int offset = initialOffset;
+            result = new AddressType();
+            result.Address = _data.GetPubKey(offset);
+            offset += 32;
+            return offset - initialOffset;
+        }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WritePubKey(Address, offset);
+            offset += 32;
+            return offset - initialOffset;
+        }
+    }
+
+    public partial class Authority
+    {
+        public AddressType AddressValue { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU8((byte)Type, offset);
+            offset += 1;
+            switch (Type)
+            {
+                case AuthorityType.Address:
+                    offset += AddressValue.Serialize(_data, offset);
+                    break;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public AuthorityType Type { get; set; }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out Authority result)
+        {
+            int offset = initialOffset;
+            result = new Authority();
+            result.Type = (AuthorityType)_data.GetU8(offset);
+            offset += 1;
+            switch (result.Type)
+            {
+                case AuthorityType.Address:
+                    {
+                        AddressType tmpAddressValue = new AddressType();
+                        offset += AddressType.Deserialize(_data, offset, out tmpAddressValue);
+                        result.AddressValue = tmpAddressValue;
+                        break;
+                    }
+            }
+
+            return offset - initialOffset;
+        }
+    }
+
+    public enum Key : byte
+    {
+        Uninitialized,
+        AssetV1,
+        HashedAssetV1,
+        PluginHeaderV1,
+        PluginRegistryV1,
+        CollectionV1
+    }
+
+    public enum UpdateAuthorityType : byte
+    {
+        None,
+        Address,
+        Collection
+    }
+
+    public partial class UpdateAuthority
+    {
+        public Tuple<PublicKey> AddressValue { get; set; }
+
+        public Tuple<PublicKey> CollectionValue { get; set; }
+
+        public int Serialize(byte[] _data, int initialOffset)
+        {
+            int offset = initialOffset;
+            _data.WriteU8((byte)Type, offset);
+            offset += 1;
+            switch (Type)
+            {
+                case UpdateAuthorityType.Address:
+                    _data.WritePubKey(AddressValue.Item1, offset);
+                    offset += 32;
+                    break;
+                case UpdateAuthorityType.Collection:
+                    _data.WritePubKey(CollectionValue.Item1, offset);
+                    offset += 32;
+                    break;
+            }
+
+            return offset - initialOffset;
+        }
+
+        public UpdateAuthorityType Type { get; set; }
+
+        public static int Deserialize(ReadOnlySpan<byte> _data, int initialOffset, out UpdateAuthority result)
+        {
+            int offset = initialOffset;
+            result = new UpdateAuthority();
+            result.Type = (UpdateAuthorityType)_data.GetU8(offset);
+            offset += 1;
+            switch (result.Type)
+            {
+                case UpdateAuthorityType.Address:
+                    {
+                        PublicKey AddressItem1;
+                        AddressItem1 = _data.GetPubKey(offset);
+                        offset += 32;
+                        result.AddressValue = Tuple.Create(AddressItem1);
+                        break;
+                    }
+
+                case UpdateAuthorityType.Collection:
+                    {
+                        PublicKey CollectionItem1;
+                        CollectionItem1 = _data.GetPubKey(offset);
+                        offset += 32;
+                        result.CollectionValue = Tuple.Create(CollectionItem1);
+                        break;
+                    }
+            }
+
+            return offset - initialOffset;
+        }
+    }
+}

--- a/Solnet.Metaplex/Solnet.Metaplex.csproj
+++ b/Solnet.Metaplex/Solnet.Metaplex.csproj
@@ -5,7 +5,7 @@
         <Description>
             Solnet.Metaplex implements functionality to integrate Metaplex project into .Net applications.
         </Description>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
 
         <IsPackable>true</IsPackable>
 

--- a/Solnet.Metaplex/Solnet.Metaplex.csproj
+++ b/Solnet.Metaplex/Solnet.Metaplex.csproj
@@ -23,11 +23,9 @@
         <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.2" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-        <PackageReference Include="Solnet.Extensions" Version="6.1.0" />
-        <PackageReference Include="Solnet.Keystore" Version="6.1.0" />
-        <PackageReference Include="Solnet.Programs" Version="6.1.0" />
-        <PackageReference Include="Solnet.Rpc" Version="6.1.0" />
-        <PackageReference Include="Solnet.Wallet" Version="6.1.0" />
+        <PackageReference Include="Solana.Programs" Version="8.3.0" />
+        <PackageReference Include="Solana.Rpc" Version="8.3.0" />
+        <PackageReference Include="Solana.Wallet" Version="8.3.0" />
     </ItemGroup>
 
     <Import Project="..\SharedBuildProperties.props" />

--- a/Solnet.Metaplex/packages.lock.json
+++ b/Solnet.Metaplex/packages.lock.json
@@ -1,7 +1,7 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0": {
+    "net8.0": {
       "Microsoft.Extensions.Logging": {
         "type": "Direct",
         "requested": "[6.0.0, )",

--- a/Solnet.Metaplex/packages.lock.json
+++ b/Solnet.Metaplex/packages.lock.json
@@ -41,53 +41,31 @@
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
       },
-      "Solnet.Extensions": {
+      "Solana.Programs": {
         "type": "Direct",
-        "requested": "[6.1.0, )",
-        "resolved": "6.1.0",
-        "contentHash": "jTs3CNeA1/FSdDBMDy/MfrTx8Z3pBc9qMRFDC2lgkW8SwHfL9LG0tso/BYsckEKXPpODUxe08xCrCWtLg/Hw1Q==",
+        "requested": "[8.3.0, )",
+        "resolved": "8.3.0",
+        "contentHash": "hIyt1AkPRFLRkDRsYuNS8mwkQSIO6Ji2/mudONLwcQ+ILTqGM4iEMUP6BjzStInyookX10HZX0nKS76mkzhgiw==",
         "dependencies": {
-          "Solnet.Programs": "6.1.0",
-          "Solnet.Rpc": "6.1.0",
-          "Solnet.Wallet": "6.1.0"
+          "Solana.Rpc": "8.3.0"
         }
       },
-      "Solnet.KeyStore": {
+      "Solana.Rpc": {
         "type": "Direct",
-        "requested": "[6.1.0, )",
-        "resolved": "6.1.0",
-        "contentHash": "CkFUXyWLahJh5KeRLNd2BqEFaeosGNhsPmmrZY9yUM92H/4hvNnw84J1RWIbw5nfsczNMp8iYf4l265+sZcKTA==",
-        "dependencies": {
-          "Chaos.NaCl.Standard": "1.0.0",
-          "Portable.BouncyCastle": "1.9.0",
-          "Solnet.Wallet": "6.1.0"
-        }
-      },
-      "Solnet.Programs": {
-        "type": "Direct",
-        "requested": "[6.1.0, )",
-        "resolved": "6.1.0",
-        "contentHash": "q48c+KUaA+wpa/Fi3Q+tKiDwNIRlYEilwJcqOqVFqO8bC6nn2EYQRVxs8myEjBblsm+t2B5aCSS7Py+HAl9pEA==",
-        "dependencies": {
-          "Solnet.Rpc": "6.1.0"
-        }
-      },
-      "Solnet.Rpc": {
-        "type": "Direct",
-        "requested": "[6.1.0, )",
-        "resolved": "6.1.0",
-        "contentHash": "vTAT+WlWgamnRbfRBbV018aWiDXeXDCr7iBTOqIEpiZ4in2IfXC+K4upIPvL3H0KOSpApjVWm3mbuN4kao5IVQ==",
+        "requested": "[8.3.0, )",
+        "resolved": "8.3.0",
+        "contentHash": "1GDMxsgHmpW93NyQ9+KzQVuu+UIngEiZhaVDzXPUyD+QRsMC+fNOoxI0K5V1nCcJEv+204V9aUgUhoaB978WIg==",
         "dependencies": {
           "Microsoft.Extensions.Logging": "6.0.0",
           "Microsoft.Extensions.Logging.Console": "6.0.0",
-          "Solnet.Wallet": "6.1.0"
+          "Solana.Wallet": "8.3.0"
         }
       },
-      "Solnet.Wallet": {
+      "Solana.Wallet": {
         "type": "Direct",
-        "requested": "[6.1.0, )",
-        "resolved": "6.1.0",
-        "contentHash": "qAacwo1RegP36lMqs5wIuvF5FIKUS3KWqbg0NfQMALwtAK040wDePRjxBmP/ovvx+UkWTx6FXRlSq0yXaKiolA==",
+        "requested": "[8.3.0, )",
+        "resolved": "8.3.0",
+        "contentHash": "KWCybD7wcnOM8NIUxnjn/QYY487Fevv2cvJhA27bFWeux0I5ThEbXBXMQuZ5YVc4VKRRpy+ULXfuoL6M83kASg==",
         "dependencies": {
           "Chaos.NaCl.Standard": "1.0.0",
           "Portable.BouncyCastle": "1.9.0"


### PR DESCRIPTION
Metaplex Core 0.6.1 

Used Solnet.Anchor to reconstruct the instruction schema, accounts, types and models. Fixed the serialize and deserialize for all the types due to having custom discriminators.

Full SDK support including plugins